### PR TITLE
fix: migration helper

### DIFF
--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -71,11 +71,27 @@ async function updateMigrationRegistry(varName: string, tag: string) {
 	}
 
 	const arrayRegex = /(export const migrations: Migration\[\] = \[)(.*)(\];)/s;
-	content = content.replace(arrayRegex, (_, start, middle, end) => {
-		const currentItems = middle.trim();
-		const newItems = currentItems ? `${currentItems}, ${varName}` : varName;
-		return `${start}${newItems}${end}`;
-	});
+
+	content = content.replace(
+		arrayRegex,
+		(_, start: string, middle: string, end: string) => {
+			const items = middle
+				.split(/[\s,]+/)
+				.map((item) => item.trim())
+				.filter(Boolean);
+
+			if (!items.includes(varName)) {
+				items.push(varName);
+			}
+
+			const formattedItems =
+				items.length > 0 ? `\n  ${items.join(',\n  ')},\n` : '';
+
+			return `${start}${formattedItems}${end}`;
+		},
+	);
+
+	console.log('new content', content);
 
 	await Bun.write(indexPath, content);
 }


### PR DESCRIPTION
## Description

Issue was observed that migration helper couldn't handle trailing commas in the exported migration array when adding new entries, to address this the system was refactored to split by using regex to handle this exception as well as providing an extra layer of protection against duplicate migrations.

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [x] Builds & runs on Windows
- [ ] Builds & runs on Linux

---

## Additional Notes

> N/A