### PR TITLE
Fix: login page

### DIFF
--- a/apps/webpanel/src/pages/login/index.tsx
+++ b/apps/webpanel/src/pages/login/index.tsx
@@ -36,7 +36,7 @@ export function LoginForm({
 
 			if (err.status === 401) {
 				setError('Invalid Credentials');
-			} else if (err.name === 'ApiError') {
+			} else {
 				setError(err.data?.error ?? err.message);
 			}
 		});

--- a/apps/webpanel/src/pages/login/index.tsx
+++ b/apps/webpanel/src/pages/login/index.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from '@/hooks/use-auth';
+import type { ApiError } from '@fxmanager/shared/types';
 import { Button } from '@fxmanager/ui/components/button';
 import {
 	Field,
@@ -30,9 +31,15 @@ export function LoginForm({
 
 	function handleSubmit(e: React.SubmitEvent<HTMLFormElement>) {
 		e.preventDefault();
-		login(formData.username, formData.password).catch((err) =>
-			setError((err as Error).message),
-		);
+		login(formData.username, formData.password).catch((error) => {
+			const err = error as ApiError<{ error?: string }>;
+
+			if (err.status === 401) {
+				setError('Invalid Credentials');
+			} else if (err.name === 'ApiError') {
+				setError(err.data?.error ?? err.message);
+			}
+		});
 	}
 
 	return (

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -15,11 +15,11 @@ export interface PaginatedResponse<T> {
 	pageSize: number;
 }
 
-export class ApiError extends Error {
+export class ApiError<T = unknown> extends Error {
 	status: number;
-	data: unknown;
+	data?: T;
 
-	constructor(message: string, status: number, data: unknown = null) {
+	constructor(message: string, status: number, data?: T) {
 		super(message);
 		this.name = 'ApiError';
 		this.status = status;


### PR DESCRIPTION
## Description

This PR addresses a minor issue encountered when logging in with invalid credentials where it would incorrectly display the reason why the error failed. To address this changes were made to provide ApiError class with templating to properly type the data within it and display `invalid credentials` if the response returns a 401 status.

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [x] Builds & runs on Windows
- [ ] Builds & runs on Linux

---

## Additional Notes

<!--
	Any extra details you wish to share, i.e.:
	* Unable to test on linux -> state why for context
	* Request feedback
	* Explain why the PR is listed as a Draft
	* List todo steps requiring discussion
-->
