### PR TITLE
feat: performance metrics

### DIFF
--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -13,6 +13,7 @@ import internalRoutes from './routes/internal';
 import { ProcessManager } from './modules/process.manager';
 import { GameManager } from './modules/game.manager';
 import { ConfigManager } from './modules/config.manager';
+import { perfManager } from './modules/perf.manager';
 import { applyMigrations } from '@fxmanager/database';
 
 applyMigrations();
@@ -70,6 +71,8 @@ fastify.get('/api/health', async () => {
 
 const pm = new ProcessManager();
 const gm = new GameManager();
+
+perfManager.start();
 
 fastify.register(apiRoutes, { prefix: '/api', pm, gm });
 fastify.register(internalRoutes, { prefix: '/internal', pm, gm });

--- a/apps/core/src/modules/perf.manager.ts
+++ b/apps/core/src/modules/perf.manager.ts
@@ -6,6 +6,7 @@ import {
 import { diffPerfs, didPerfReset, parseRawPerf } from './perf/perf.parser';
 import { wsManager } from './ws.manager';
 
+// TODO: replace this with a utility function for getting the actual server endpoint at a later date
 const PERF_PORT = 30120;
 const PERF_ENDPOINT = `http://localhost:${PERF_PORT}/perf.json`;
 

--- a/apps/core/src/modules/perf.manager.ts
+++ b/apps/core/src/modules/perf.manager.ts
@@ -1,0 +1,82 @@
+import {
+	PERF_WINDOW_MS,
+	type PerfSnapshot,
+	type RawPerf,
+} from '@fxmanager/shared/types';
+import { diffPerfs, didPerfReset, parseRawPerf } from './perf/perf.parser';
+import { wsManager } from './ws.manager';
+
+const PERF_PORT = 30120;
+const PERF_ENDPOINT = `http://localhost:${PERF_PORT}/perf.json`;
+
+const SAMPLE_INTERVAL_MS = 30_000;
+
+class PerfManager {
+	private interval: ReturnType<typeof setInterval> | null = null;
+	private lastRaw: RawPerf | null = null;
+	private recent: PerfSnapshot[] = [];
+
+	/** Poll `/perf.json` continuously, regardless of who started the fxserver. */
+	start(): void {
+		if (this.interval) return;
+		void this.tick();
+		this.interval = setInterval(() => void this.tick(), SAMPLE_INTERVAL_MS);
+	}
+
+	stop(): void {
+		if (this.interval) {
+			clearInterval(this.interval);
+			this.interval = null;
+		}
+		this.lastRaw = null;
+		this.recent = [];
+	}
+
+	/** The last 30 min of samples, used to backfill freshly connected clients. */
+	getRecent(): PerfSnapshot[] {
+		return this.recent;
+	}
+
+	private async fetchRawPerfData(): Promise<RawPerf | null> {
+		try {
+			const res = await fetch(PERF_ENDPOINT, {
+				signal: AbortSignal.timeout(SAMPLE_INTERVAL_MS / 2),
+			});
+			if (!res.ok) return null;
+			return parseRawPerf(await res.text());
+		} catch {
+			return null;
+		}
+	}
+
+	private async tick(): Promise<void> {
+		const raw = await this.fetchRawPerfData();
+
+		if (!raw || Object.keys(raw).length === 0) {
+			this.lastRaw = null;
+			return;
+		}
+
+		if (!this.lastRaw || didPerfReset(raw, this.lastRaw)) {
+			this.lastRaw = raw;
+			return;
+		}
+
+		const snapshot: PerfSnapshot = {
+			ts: Date.now(),
+			threads: diffPerfs(raw, this.lastRaw),
+		};
+		this.lastRaw = raw;
+
+		const cutoff = Date.now() - PERF_WINDOW_MS;
+		this.recent = [...this.recent, snapshot].filter((s) => s.ts >= cutoff);
+
+		wsManager.broadcast<PerfSnapshot>({
+			channel: 'perf',
+			event: 'sample',
+			data: snapshot,
+		});
+	}
+}
+
+export const perfManager = new PerfManager();

--- a/apps/core/src/modules/perf/perf.parser.test.ts
+++ b/apps/core/src/modules/perf/perf.parser.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'bun:test';
+import { diffPerfs, didPerfReset, parseRawPerf } from './perf.parser';
+
+const sample = `# HELP tickTime time spent
+# TYPE tickTime histogram
+tickTime_bucket{name="svMain",le="0.005"} 10
+tickTime_bucket{name="svMain",le="0.01"} 25
+tickTime_bucket{name="svMain",le="+Inf"} 30
+tickTime_sum{name="svMain"} 1.5
+tickTime_count{name="svMain"} 30
+tickTime_bucket{name="svSync",le="0.005"} 5
+tickTime_bucket{name="svSync",le="0.01"} 8
+tickTime_bucket{name="svSync",le="+Inf"} 8
+tickTime_sum{name="svSync"} 0.4
+tickTime_count{name="svSync"} 8
+tickTime_bucket{name="svNetwork",le="0.005"} 2
+tickTime_bucket{name="svNetwork",le="0.01"} 3
+tickTime_bucket{name="svNetwork",le="+Inf"} 4
+tickTime_sum{name="svNetwork"} 0.2
+tickTime_count{name="svNetwork"} 4
+`;
+
+describe('parseRawPerf', () => {
+	it('extracts count and sum for a thread', () => {
+		const perf = parseRawPerf(sample);
+		expect(perf.svMain.count).toBe(30);
+		expect(perf.svMain.sum).toBeCloseTo(1.5);
+	});
+
+	it('extracts cumulative buckets in le order including +Inf', () => {
+		const perf = parseRawPerf(sample);
+		expect(perf.svMain.buckets).toEqual([10, 25, 30]);
+	});
+
+	it('parses all three threads', () => {
+		const perf = parseRawPerf(sample);
+		expect(Object.keys(perf).sort()).toEqual(['svMain', 'svNetwork', 'svSync']);
+		expect(perf.svSync.count).toBe(8);
+		expect(perf.svNetwork.count).toBe(4);
+	});
+
+	it('ignores comments, blank lines and unrelated metrics', () => {
+		const noisy = `# a comment\n\nunrelated_metric{foo="bar"} 99\n${sample}`;
+		const perf = parseRawPerf(noisy);
+		expect(perf.svMain.count).toBe(30);
+		expect(Object.keys(perf)).toHaveLength(3);
+	});
+
+	it('omits threads that are absent from the payload', () => {
+		const onlyMain = `tickTime_bucket{name="svMain",le="0.005"} 1
+tickTime_bucket{name="svMain",le="+Inf"} 2
+tickTime_sum{name="svMain"} 0.1
+tickTime_count{name="svMain"} 2
+`;
+		const perf = parseRawPerf(onlyMain);
+		expect(Object.keys(perf)).toEqual(['svMain']);
+		expect(perf.svSync).toBeUndefined();
+	});
+});
+
+describe('diffPerfs', () => {
+	it('subtracts count, sum and buckets element-wise', () => {
+		const prev = parseRawPerf(sample);
+		const currText = sample
+			.replace(
+				'tickTime_count{name="svMain"} 30',
+				'tickTime_count{name="svMain"} 50',
+			)
+			.replace(
+				'tickTime_sum{name="svMain"} 1.5',
+				'tickTime_sum{name="svMain"} 2.5',
+			)
+			.replace(
+				'tickTime_bucket{name="svMain",le="0.005"} 10',
+				'tickTime_bucket{name="svMain",le="0.005"} 14',
+			)
+			.replace(
+				'tickTime_bucket{name="svMain",le="0.01"} 25',
+				'tickTime_bucket{name="svMain",le="0.01"} 33',
+			)
+			.replace(
+				'tickTime_bucket{name="svMain",le="+Inf"} 30',
+				'tickTime_bucket{name="svMain",le="+Inf"} 50',
+			);
+		const curr = parseRawPerf(currText);
+
+		const delta = diffPerfs(curr, prev);
+		expect(delta.svMain.count).toBe(20);
+		expect(delta.svMain.sum).toBeCloseTo(1.0);
+		expect(delta.svMain.buckets).toEqual([4, 8, 20]);
+	});
+});
+
+describe('didPerfReset', () => {
+	it('returns false when all values grew or held', () => {
+		const prev = parseRawPerf(sample);
+		const curr = parseRawPerf(sample); // identical => no regression
+		expect(didPerfReset(curr, prev)).toBe(false);
+	});
+
+	it('returns true when a counter regressed (server restart)', () => {
+		const prev = parseRawPerf(sample);
+		const resetText = sample.replace(
+			'tickTime_count{name="svMain"} 30',
+			'tickTime_count{name="svMain"} 3',
+		);
+		const curr = parseRawPerf(resetText);
+		expect(didPerfReset(curr, prev)).toBe(true);
+	});
+});

--- a/apps/core/src/modules/perf/perf.parser.ts
+++ b/apps/core/src/modules/perf/perf.parser.ts
@@ -1,0 +1,118 @@
+import {
+	PERF_THREADS,
+	type PerfThread,
+	type PerfThreadCounts,
+	type RawPerf,
+} from '@fxmanager/shared/types';
+
+// Matches the FXServer `/perf/` Prometheus lines, e.g.
+//   tickTime_count{name="svMain"} 30
+//   tickTime_sum{name="svMain"} 1.5
+//   tickTime_bucket{name="svMain",le="0.005"} 10
+const LINE_RE =
+	/^tickTime_(count|sum|bucket)\{name="(svMain|svSync|svNetwork)"(?:,le="([^"]+)")?\}\s+(.+)$/;
+
+interface BuildingThread {
+	count?: number;
+	sum?: number;
+	bucketPairs: { le: number; value: number }[];
+}
+
+/**
+ * Parses raw FXServer `/perf/` Prometheus text into per-thread histogram
+ * counts. Threads absent from the payload are omitted from the result.
+ */
+export function parseRawPerf(text: string): RawPerf {
+	const building = new Map<PerfThread, BuildingThread>();
+
+	for (const rawLine of text.split('\n')) {
+		const line = rawLine.trim();
+		if (!line || line.startsWith('#')) continue;
+
+		const match = LINE_RE.exec(line);
+		if (!match) continue;
+
+		const [, kind, threadName, le, valueStr] = match;
+		const value = Number(valueStr);
+		if (!Number.isFinite(value)) continue;
+
+		const thread = threadName as PerfThread;
+		let entry = building.get(thread);
+		if (!entry) {
+			entry = { bucketPairs: [] };
+			building.set(thread, entry);
+		}
+
+		if (kind === 'count') {
+			entry.count = value;
+		} else if (kind === 'sum') {
+			entry.sum = value;
+		} else if (kind === 'bucket') {
+			const boundary = le === '+Inf' ? Infinity : Number(le);
+			entry.bucketPairs.push({ le: boundary, value });
+		}
+	}
+
+	const result = {} as RawPerf;
+	for (const thread of PERF_THREADS) {
+		const entry = building.get(thread);
+		if (!entry) continue;
+
+		const sorted = [...entry.bucketPairs].sort((a, b) => a.le - b.le);
+		result[thread] = {
+			count: entry.count ?? 0,
+			sum: entry.sum ?? 0,
+			buckets: sorted.map((p) => p.value),
+		} satisfies PerfThreadCounts;
+	}
+
+	return result;
+}
+
+/**
+ * Returns the per-window delta between two scrapes (curr - prev), thread by
+ * thread and bucket by bucket. When a thread has no previous snapshot, the
+ * current values are returned unchanged.
+ */
+export function diffPerfs(curr: RawPerf, prev: RawPerf): RawPerf {
+	const result = {} as RawPerf;
+
+	for (const thread of PERF_THREADS) {
+		const c = curr[thread];
+		if (!c) continue;
+
+		const p = prev[thread];
+		if (!p) {
+			result[thread] = c;
+			continue;
+		}
+
+		result[thread] = {
+			count: c.count - p.count,
+			sum: c.sum - p.sum,
+			buckets: c.buckets.map((v, i) => v - (p.buckets[i] ?? 0)),
+		};
+	}
+
+	return result;
+}
+
+/**
+ * Detects an FXServer restart: the `/perf/` counters are monotonic, so any
+ * value in `curr` lower than `prev` means they were reset.
+ */
+export function didPerfReset(curr: RawPerf, prev: RawPerf): boolean {
+	for (const thread of PERF_THREADS) {
+		const c = curr[thread];
+		const p = prev[thread];
+		if (!c || !p) continue;
+
+		if (c.count < p.count || c.sum < p.sum) return true;
+
+		for (let i = 0; i < c.buckets.length; i++) {
+			if ((c.buckets[i] ?? 0) < (p.buckets[i] ?? 0)) return true;
+		}
+	}
+
+	return false;
+}

--- a/apps/core/src/routes/api/sockets.ts
+++ b/apps/core/src/routes/api/sockets.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { UserPermissions } from '@fxmanager/shared/constants';
 import type {
 	OnlinePlayer,
+	PerfSnapshot,
 	ProcessOutputLine,
 	ResourceInitialData,
 	ServerState,
@@ -11,6 +12,7 @@ import { sessionAuth } from '../../middleware/session';
 import { wsManager } from '../../modules/ws.manager';
 import type { AuthedRequest, RouteModule } from '../../types';
 import { resourceManager } from '../../modules/resource.manager';
+import { perfManager } from '../../modules/perf.manager';
 
 wsManager.addCheck('console', (admin) => {
 	return PermissionManager.has(
@@ -96,6 +98,11 @@ const wsEndpoints: RouteModule['handler'] = async (fastify, { pm, gm }) => {
 
 	wsManager.setInitialData<ResourceInitialData>('resourcelist', () => {
 		return resourceManager.getResourceList();
+	});
+
+	// backfill new clients with the last 30 min of samples
+	wsManager.setInitialData<PerfSnapshot[]>('perf', () => {
+		return perfManager.getRecent();
 	});
 };
 

--- a/apps/webpanel/src/hooks/ws-channels/use-perf.ts
+++ b/apps/webpanel/src/hooks/ws-channels/use-perf.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { PERF_WINDOW_MS, type PerfSnapshot } from '@fxmanager/shared/types';
+import { useWSBase } from './use-ws-core';
+
+/**
+ * Subscribes to the `perf` channel: seeds the series from the initial backfill,
+ * then appends each live `sample` broadcast, trimming to the last 30 min.
+ */
+export function usePerfSocket() {
+	const { subscribe, unsubscribe, on } = useWSBase();
+	const [samples, setSamples] = useState<PerfSnapshot[]>([]);
+
+	useEffect(() => {
+		subscribe('perf');
+
+		const trim = (list: PerfSnapshot[]) => {
+			const cutoff = Date.now() - PERF_WINDOW_MS;
+			return list.filter((s) => s.ts >= cutoff);
+		};
+
+		const offInitial = on<PerfSnapshot[]>('perf', 'initial', ({ data }) => {
+			setSamples(trim(data));
+		});
+
+		const offSample = on<PerfSnapshot>('perf', 'sample', ({ data }) => {
+			setSamples((prev) => trim([...prev, data]));
+		});
+
+		return () => {
+			offInitial();
+			offSample();
+			unsubscribe('perf');
+		};
+	}, [subscribe, unsubscribe, on]);
+
+	return { samples };
+}

--- a/apps/webpanel/src/pages/dashboard/index.tsx
+++ b/apps/webpanel/src/pages/dashboard/index.tsx
@@ -1,12 +1,4 @@
-import {
-	Activity,
-	Clock,
-	LayoutDashboard,
-	Play,
-	RefreshCw,
-	Square,
-} from 'lucide-react';
-import { HandleServerAction } from '@/lib/query';
+import { Activity, Clock, LayoutDashboard } from 'lucide-react';
 import { formatUptime } from '@/lib/utils';
 import { STATUS_VARIANT } from '@/static/server-state';
 import { PageHeader } from '@/components/page-header';
@@ -18,7 +10,6 @@ import {
 	CardHeader,
 	CardTitle,
 } from '@fxmanager/ui/components/card';
-import { Button } from '@fxmanager/ui/components/button';
 
 /* ToDo:
  * Consider adding wider details on process health
@@ -29,8 +20,6 @@ import { Button } from '@fxmanager/ui/components/button';
 export default function DashboardPage() {
 	const { state: serverState } = useServerStateSocket();
 	const status = serverState?.status ?? 'stopped';
-	const isRunning = status === 'running';
-	const canStart = status === 'stopped' || status === 'crashed';
 
 	const stats = [
 		{
@@ -52,7 +41,7 @@ export default function DashboardPage() {
 			<PageHeader
 				Icon={LayoutDashboard}
 				title="Dashboard"
-				description="Server overview and controls."
+				description="Server overview."
 			/>
 
 			<div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
@@ -70,41 +59,6 @@ export default function DashboardPage() {
 					</Card>
 				))}
 			</div>
-
-			<Card className="bg-card/50 right-0">
-				<CardHeader>
-					<CardTitle className="text-sm font-medium">Server Controls</CardTitle>
-				</CardHeader>
-				<CardContent className="flex flex-wrap gap-2">
-					<Button
-						size="sm"
-						variant="outline"
-						disabled={!canStart}
-						onClick={() => HandleServerAction('start')}
-						className="border-green-500/30 text-green-400 hover:bg-green-500/10 disabled:opacity-40"
-					>
-						<Play className="mr-1.5 h-3.5 w-3.5" /> Start
-					</Button>
-					<Button
-						size="sm"
-						variant="outline"
-						disabled={!isRunning}
-						onClick={() => HandleServerAction('stop')}
-						className="border-destructive/30 text-destructive hover:bg-destructive/10 disabled:opacity-40"
-					>
-						<Square className="mr-1.5 h-3.5 w-3.5" /> Stop
-					</Button>
-					<Button
-						size="sm"
-						variant="outline"
-						disabled={!isRunning}
-						onClick={() => HandleServerAction('restart')}
-						className="border-primary/30 text-primary hover:bg-primary/10 disabled:opacity-40"
-					>
-						<RefreshCw className="mr-1.5 h-3.5 w-3.5" /> Restart
-					</Button>
-				</CardContent>
-			</Card>
 		</div>
 	);
 }

--- a/apps/webpanel/src/pages/dashboard/index.tsx
+++ b/apps/webpanel/src/pages/dashboard/index.tsx
@@ -10,6 +10,7 @@ import {
 	CardHeader,
 	CardTitle,
 } from '@fxmanager/ui/components/card';
+import { PerfDistribution } from './perf-distribution';
 
 /* ToDo:
  * Consider adding wider details on process health
@@ -44,20 +45,26 @@ export default function DashboardPage() {
 				description="Server overview."
 			/>
 
-			<div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-				{stats.map(({ label, value, icon: Icon }) => (
-					<Card key={label} className="bg-card/50">
-						<CardHeader className="flex flex-row items-center justify-between pb-2 pt-4">
-							<CardTitle className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-								{label}
-							</CardTitle>
-							<Icon className="h-4 w-4 text-muted-foreground" />
-						</CardHeader>
-						<CardContent className="pb-4">
-							<div className="text-xl font-bold">{value}</div>
-						</CardContent>
-					</Card>
-				))}
+			<div className="grid gap-4 lg:grid-cols-3">
+				<div className="grid content-start gap-4 sm:grid-cols-2 lg:col-span-1 lg:grid-cols-1">
+					{stats.map(({ label, value, icon: Icon }) => (
+						<Card key={label} className="bg-card/50">
+							<CardHeader className="flex flex-row items-center justify-between pb-2 pt-4">
+								<CardTitle className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+									{label}
+								</CardTitle>
+								<Icon className="h-4 w-4 text-muted-foreground" />
+							</CardHeader>
+							<CardContent className="pb-4">
+								<div className="text-2xl font-bold">{value}</div>
+							</CardContent>
+						</Card>
+					))}
+				</div>
+
+				<div className="lg:col-span-2">
+					<PerfDistribution />
+				</div>
 			</div>
 		</div>
 	);

--- a/apps/webpanel/src/pages/dashboard/perf-buckets.ts
+++ b/apps/webpanel/src/pages/dashboard/perf-buckets.ts
@@ -1,0 +1,16 @@
+// FXServer tickTime bucket upper-bounds (ms); the final band is the +Inf bucket.
+const BUCKET_MS = [1, 2, 4, 6, 8, 10, 15, 20, 30, 50, 70, 100, 150, 250];
+const BAND_LABELS = [...BUCKET_MS.map(String), '+Inf'];
+export const BANDS = BAND_LABELS.length;
+
+/** Pretty label for a band index, e.g. `1ms` or `+Inf`. */
+export function bandLabel(index: number): string {
+	const raw = BAND_LABELS[index] ?? '';
+	return raw === '+Inf' ? '+Inf' : `${raw}ms`;
+}
+
+/** Fastest band green, slowest red. */
+export function bandColor(index: number): string {
+	const hue = Math.round(140 * (1 - index / (BANDS - 1)));
+	return `hsl(${hue} 70% 45%)`;
+}

--- a/apps/webpanel/src/pages/dashboard/perf-distribution.tsx
+++ b/apps/webpanel/src/pages/dashboard/perf-distribution.tsx
@@ -1,0 +1,148 @@
+import { useMemo, useState } from 'react';
+import { usePerfSocket } from '@/hooks/ws-channels/use-perf';
+import {
+	PERF_WINDOW_MS,
+	type PerfSnapshot,
+	type PerfThread,
+} from '@fxmanager/shared/types';
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from '@fxmanager/ui/components/card';
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@fxmanager/ui/components/select';
+import { BarChart3 } from 'lucide-react';
+import { BANDS, bandColor, bandLabel } from './perf-buckets';
+
+const THREADS: { value: PerfThread; label: string }[] = [
+	{ value: 'svMain', label: 'svMain' },
+	{ value: 'svNetwork', label: 'svNetwork' },
+	{ value: 'svSync', label: 'svSync' },
+];
+
+interface Aggregate {
+	frac: number[];
+	totalTicks: number;
+	windows: number;
+}
+
+function aggregate(
+	samples: PerfSnapshot[],
+	thread: PerfThread,
+): Aggregate | null {
+	const cutoff = Date.now() - PERF_WINDOW_MS;
+	let pool = samples.filter((s) => s.ts >= cutoff && s.threads[thread]);
+	if (pool.length === 0) {
+		const all = samples.filter((s) => s.threads[thread]);
+		const last = all[all.length - 1];
+		pool = last ? [last] : [];
+	}
+	if (pool.length === 0) return null;
+
+	const bucketTicks = new Array<number>(BANDS).fill(0);
+	let totalTicks = 0;
+	for (const sample of pool) {
+		const counts = sample.threads[thread];
+		if (!counts) continue;
+		let prev = 0;
+		for (let b = 0; b < BANDS; b++) {
+			const cumulative = counts.buckets[b] ?? prev;
+			bucketTicks[b] = (bucketTicks[b] ?? 0) + (cumulative - prev);
+			prev = cumulative;
+		}
+		totalTicks += counts.count || 0;
+	}
+	if (totalTicks <= 0) return null;
+
+	return {
+		frac: bucketTicks.map((t) => t / totalTicks),
+		totalTicks,
+		windows: pool.length,
+	};
+}
+
+export function PerfDistribution() {
+	const { samples } = usePerfSocket();
+	const [thread, setThread] = useState<PerfThread>('svMain');
+
+	const data = useMemo(() => aggregate(samples, thread), [samples, thread]);
+
+	return (
+		<Card>
+			<CardHeader className="flex flex-row items-start justify-between gap-2 space-y-0">
+				<div className="space-y-1.5">
+					<CardTitle className="flex items-center gap-2">
+						<BarChart3 className="h-4 w-4" />
+						{thread} performance
+					</CardTitle>
+					<CardDescription>
+						{data
+							? `Tick-time distribution over the last 30 min — ${data.totalTicks.toLocaleString()} ticks`
+							: 'No performance data yet'}
+					</CardDescription>
+				</div>
+				<Select
+					value={thread}
+					onValueChange={(v) => setThread(v as PerfThread)}
+				>
+					<SelectTrigger className="w-[130px]">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{THREADS.map(({ value, label }) => (
+							<SelectItem key={value} value={value}>
+								{label}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</CardHeader>
+			<CardContent>
+				{!data ? (
+					<div className="flex h-[260px] items-center justify-center text-center text-sm text-muted-foreground">
+						No performance data yet. Metrics appear ~30s after the server
+						starts.
+					</div>
+				) : (
+					<div className="space-y-1.5">
+						{Array.from({ length: BANDS }, (_, idx) => {
+							// render slowest (+Inf) at the top, fastest (1ms) at the bottom
+							const i = BANDS - 1 - idx;
+							const pct = (data.frac[i] ?? 0) * 100;
+							return (
+								<div
+									key={bandLabel(i)}
+									className="flex items-center gap-2 text-xs"
+								>
+									<span className="w-11 shrink-0 text-right text-muted-foreground tabular-nums">
+										{bandLabel(i)}
+									</span>
+									<div className="relative h-4 flex-1 overflow-hidden rounded bg-muted/30">
+										<div
+											className="h-full rounded"
+											style={{
+												width: `${Math.min(100, pct)}%`,
+												backgroundColor: bandColor(i),
+											}}
+										/>
+									</div>
+									<span className="w-14 shrink-0 text-right tabular-nums">
+										{pct.toFixed(1)}%
+									</span>
+								</div>
+							);
+						})}
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -8,4 +8,5 @@ export * from './players';
 export * from './security';
 export * from './settings';
 export * from './websockets';
+export * from './perf';
 export * from './whitelist';

--- a/packages/shared/src/types/perf.ts
+++ b/packages/shared/src/types/perf.ts
@@ -1,0 +1,29 @@
+export type PerfThread = 'svMain' | 'svSync' | 'svNetwork';
+
+export const PERF_THREADS: readonly PerfThread[] = [
+	'svMain',
+	'svSync',
+	'svNetwork',
+] as const;
+
+export const PERF_WINDOW_MS = 30 * 60 * 1000;
+
+/**
+ * Per-thread histogram values as scraped from `/perf/`.
+ * `buckets` are the cumulative `tickTime_bucket` counts ordered by their `le`
+ * (less-than-or-equal) boundary, the last entry being the `+Inf` bucket.
+ */
+export interface PerfThreadCounts {
+	count: number;
+	sum: number;
+	buckets: number[];
+}
+
+/** Raw (or diffed) values for all three threads. */
+export type RawPerf = Record<PerfThread, PerfThreadCounts>;
+
+/** A single stored/broadcast performance sample. */
+export interface PerfSnapshot {
+	ts: number;
+	threads: RawPerf;
+}

--- a/packages/shared/src/types/websockets.ts
+++ b/packages/shared/src/types/websockets.ts
@@ -3,6 +3,7 @@ export type Channel =
 	| 'resourcelist'
 	| 'playerlist'
 	| 'console'
+	| 'perf'
 	| `report:general`
 	| `report:${number}`;
 


### PR DESCRIPTION
## Description
This feature is trying to resolve one of the last requirements before pre-launch.

This is a step 1, we would need to extend later but we would need additional metrics saved such as playerdata count for a histogram such as the txAdmin performance overview.

However creating all of that would be insanely out of scope and quite a big PR so better we create it in building blocks.

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [x] Builds & runs on Windows
- [x] Builds & runs on Linux

---

## Additional Notes
I've also added a few tests, that way we can start doing TDD for upcoming/new features, which would make sure in 6 months when the web panel grows exponentially and we get third party PRs they do not break our original and intended logic.
