### PR TITLE
feat(core/migrate): import txAdmin players database

### DIFF
--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -15,6 +15,13 @@ import { GameManager } from './modules/game.manager';
 import { ConfigManager } from './modules/config.manager';
 import { perfManager } from './modules/perf.manager';
 import { applyMigrations } from '@fxmanager/database';
+import { MIGRATE_WORKER_FLAG, runMigrateWorker } from './migrate-worker';
+
+// when re-exec'd as a migrate worker, run the import and exit before any
+// server/port/migration bootstrapping happens
+if (process.argv.includes(MIGRATE_WORKER_FLAG)) {
+	await runMigrateWorker();
+}
 
 applyMigrations();
 // hardcode for the time being

--- a/apps/core/src/migrate-worker.ts
+++ b/apps/core/src/migrate-worker.ts
@@ -1,0 +1,68 @@
+import { repo, type ImportSummary } from '@fxmanager/database';
+
+// re-exec contract: the server re-runs its own binary with this flag to import
+// a txAdmin DB in a child process, keeping the blocking sync import off the
+// main event loop. stdout is shared with startup logs, so the result is framed
+// with a marker the parent slices out.
+export const MIGRATE_WORKER_FLAG = '--fxm-migrate-worker';
+const RESULT_MARKER = '__FXM_MIGRATE_RESULT__';
+
+type WorkerResult =
+	| { ok: true; summary: ImportSummary }
+	| { ok: false; error: string };
+
+/**
+ * Child entry: read the raw txAdmin JSON from stdin, import it, and write a
+ * marked result to stdout. Always exits; never returns to normal startup.
+ */
+export async function runMigrateWorker(): Promise<never> {
+	let result: WorkerResult;
+
+	try {
+		const raw = await Bun.stdin.text();
+
+		let json: unknown;
+		try {
+			json = JSON.parse(raw);
+		} catch {
+			throw new Error('invalid_txadmin_db');
+		}
+
+		result = { ok: true, summary: repo.migrate.fromTxAdmin(json) };
+	} catch (err) {
+		result = { ok: false, error: (err as Error).message };
+	}
+
+	await Bun.write(Bun.stdout, `\n${RESULT_MARKER}${JSON.stringify(result)}\n`);
+	process.exit(0);
+}
+
+/**
+ * Parent side: import a raw txAdmin payload by re-running this binary in worker
+ * mode. Rejects with `invalid_txadmin_db` for unrecognisable payloads.
+ */
+export async function runMigrateInChildProcess(
+	raw: string,
+): Promise<ImportSummary> {
+	const proc = Bun.spawn([process.execPath, Bun.main, MIGRATE_WORKER_FLAG], {
+		stdin: 'pipe',
+		stdout: 'pipe',
+		stderr: 'inherit',
+	});
+
+	proc.stdin.write(raw);
+	await proc.stdin.end();
+
+	const out = await new Response(proc.stdout).text();
+	await proc.exited;
+
+	const marker = out.lastIndexOf(RESULT_MARKER);
+	if (marker === -1) throw new Error('migrate_worker_failed');
+
+	const result = JSON.parse(
+		out.slice(marker + RESULT_MARKER.length).trim(),
+	) as WorkerResult;
+
+	if (!result.ok) throw new Error(result.error);
+	return result.summary;
+}

--- a/apps/core/src/routes/api/index.ts
+++ b/apps/core/src/routes/api/index.ts
@@ -6,6 +6,7 @@ import WhitelistModule from './whitelist';
 import WsModule from './sockets';
 import SettingsModule from './settings';
 import ResourcesModule from './resources';
+import MigrateModule from './migrate';
 
 const apiRoutes: RouteModule['handler'] = async (fastify, options) => {
 	fastify.register(AuthModule.handler, {
@@ -41,6 +42,11 @@ const apiRoutes: RouteModule['handler'] = async (fastify, options) => {
 	fastify.register(WsModule.handler, {
 		...options,
 		prefix: WsModule.prefix,
+	});
+
+	fastify.register(MigrateModule.handler, {
+		...options,
+		prefix: MigrateModule.prefix,
 	});
 };
 

--- a/apps/core/src/routes/api/migrate.ts
+++ b/apps/core/src/routes/api/migrate.ts
@@ -1,0 +1,83 @@
+import type { FastifyRequest } from 'fastify';
+import type { AuthedRequest, RouteModule } from '../../types';
+import { sessionAuth } from '../../middleware/session';
+import { PermissionManager } from '@fxmanager/shared/utils';
+import { UserPermissions } from '@fxmanager/shared/constants';
+import { repo, type ImportSummary } from '@fxmanager/database';
+import type { ApiResponse } from '@fxmanager/shared/types';
+import { runMigrateInChildProcess } from '../../migrate-worker';
+
+// txAdmin player databases can be several megabytes; lift the body limit well
+// above Fastify's 1MB default for this upload endpoint.
+const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
+
+const MigrateEndpoints: RouteModule['handler'] = async (fastify) => {
+	fastify.addHook('preHandler', sessionAuth);
+
+	const keepRawBody = (
+		_request: FastifyRequest,
+		body: string,
+		done: (err: Error | null, parsed?: unknown) => void,
+	) => done(null, body);
+
+	fastify.addContentTypeParser(
+		'application/json',
+		{ parseAs: 'string', bodyLimit: MAX_UPLOAD_BYTES },
+		keepRawBody,
+	);
+	fastify.addContentTypeParser(
+		'application/octet-stream',
+		{ parseAs: 'string', bodyLimit: MAX_UPLOAD_BYTES },
+		keepRawBody,
+	);
+
+	fastify.post('/', { bodyLimit: MAX_UPLOAD_BYTES }, async (request, reply) => {
+		const { admin } = request as AuthedRequest;
+
+		if (!PermissionManager.has(admin.permissions, UserPermissions.MASTER)) {
+			return reply.code(403).send({
+				success: false,
+				error: 'Not authorized',
+			});
+		}
+
+		try {
+			const summary = await runMigrateInChildProcess(request.body as string);
+
+			try {
+				repo.audit.log({
+					adminId: admin.id,
+					action: 'migrate.txadmin',
+					metadata: summary as unknown as Record<string, unknown>,
+				});
+			} catch (auditErr) {
+				console.error('/api/migrate audit log failed:', auditErr);
+			}
+
+			return {
+				success: true,
+				data: summary,
+			} satisfies ApiResponse<ImportSummary>;
+		} catch (err) {
+			const message = (err as Error).message;
+
+			if (message === 'invalid_txadmin_db') {
+				return reply.code(400).send({
+					success: false,
+					error: 'Uploaded file is not a valid txAdmin players database',
+				});
+			}
+
+			console.error('/api/migrate failed:', err);
+			return reply.code(500).send({
+				success: false,
+				error: 'An error occurred while importing the database',
+			});
+		}
+	});
+};
+
+export default {
+	prefix: '/migrate',
+	handler: MigrateEndpoints,
+} satisfies RouteModule;

--- a/packages/database/src/import/txadmin.importer.test.ts
+++ b/packages/database/src/import/txadmin.importer.test.ts
@@ -1,0 +1,356 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { drizzle, type BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import { eq } from 'drizzle-orm';
+import * as schema from '../schema';
+import { migrations, runMigrations } from '../migrations';
+import { importTxAdmin } from './txadmin.importer';
+import type { TxAdminImport } from './txadmin';
+
+type DB = BunSQLiteDatabase<typeof schema>;
+
+function freshDb(): DB {
+	const sqlite = new Database(':memory:');
+	sqlite.run('PRAGMA foreign_keys = ON;');
+
+	// migrations log to console; silence to keep test output pristine
+	const log = console.log;
+	console.log = () => {};
+	runMigrations(sqlite, migrations);
+	console.log = log;
+
+	return drizzle(sqlite, { schema });
+}
+
+function emptyImport(): TxAdminImport {
+	return { players: [], actions: [], whitelist: [] };
+}
+
+let db: DB;
+beforeEach(() => {
+	db = freshDb();
+});
+
+describe('importTxAdmin - players', () => {
+	const data: TxAdminImport = {
+		...emptyImport(),
+		players: [
+			{
+				name: 'CaliChris',
+				playtime: 1_440_000,
+				firstSeen: new Date(1775845668 * 1000),
+				lastSeen: new Date(1781156576 * 1000),
+				identifiers: [
+					{ type: 'license', value: 'abc' },
+					{ type: 'discord', value: '123' },
+				],
+				note: { content: 'a note', issuedAt: new Date(1779553664 * 1000) },
+			},
+		],
+	};
+
+	it('inserts a new player with all identifiers', () => {
+		importTxAdmin(db, data);
+
+		const players = db.select().from(schema.players).all();
+		expect(players).toHaveLength(1);
+		expect(players[0].name).toBe('CaliChris');
+		expect(players[0].playtime).toBe(1_440_000);
+
+		const ids = db.select().from(schema.playerIdentifiers).all();
+		expect(ids.map((i) => i.value).sort()).toEqual(['123', 'abc']);
+	});
+
+	it('imports the player note attached to the player', () => {
+		importTxAdmin(db, data);
+
+		const notes = db.select().from(schema.playerNotes).all();
+		expect(notes).toHaveLength(1);
+		expect(notes[0].content).toBe('a note');
+		expect(notes[0].issuer).toBeNull();
+	});
+
+	it('is idempotent: re-running creates no duplicate players, ids or notes', () => {
+		importTxAdmin(db, data);
+		const summary = importTxAdmin(db, data);
+
+		expect(db.select().from(schema.players).all()).toHaveLength(1);
+		expect(db.select().from(schema.playerIdentifiers).all()).toHaveLength(2);
+		expect(db.select().from(schema.playerNotes).all()).toHaveLength(1);
+		expect(summary.players.created).toBe(0);
+		expect(summary.players.matched).toBe(1);
+	});
+
+	it('reports created counts in the summary', () => {
+		const summary = importTxAdmin(db, data);
+		expect(summary.players.created).toBe(1);
+		expect(summary.identifiers.created).toBe(2);
+		expect(summary.notes.created).toBe(1);
+	});
+});
+
+describe('importTxAdmin - actions matched to existing players', () => {
+	const data: TxAdminImport = {
+		...emptyImport(),
+		players: [
+			{
+				name: 'P1',
+				playtime: 0,
+				firstSeen: new Date(1000 * 1000),
+				lastSeen: new Date(2000 * 1000),
+				identifiers: [{ type: 'license', value: 'abc' }],
+				note: null,
+			},
+		],
+		actions: [
+			{
+				type: 'ban',
+				reason: 'Cheating',
+				identifiers: [{ type: 'license', value: 'abc' }],
+				playerName: 'P1',
+				createdAt: new Date(1775855632 * 1000),
+				expiresAt: null,
+				revokedAt: null,
+				acked: false,
+			},
+		],
+	};
+
+	it('attaches the ban to the existing player without creating a stub', () => {
+		const summary = importTxAdmin(db, data);
+
+		expect(db.select().from(schema.players).all()).toHaveLength(1);
+		expect(summary.stubPlayers).toBe(0);
+
+		const bans = db.select().from(schema.bans).all();
+		expect(bans).toHaveLength(1);
+		expect(bans[0].playerId).toBe(1);
+		expect(bans[0].reason).toBe('Cheating');
+		expect(bans[0].issuer).toBeNull();
+	});
+});
+
+describe('importTxAdmin - orphan actions', () => {
+	const data: TxAdminImport = {
+		...emptyImport(),
+		actions: [
+			{
+				type: 'ban',
+				reason: 'on-sight',
+				identifiers: [{ type: 'license', value: 'orphan' }],
+				playerName: 'GhostBanned',
+				createdAt: new Date(1775855632 * 1000),
+				expiresAt: null,
+				revokedAt: null,
+				acked: false,
+			},
+		],
+	};
+
+	it('creates a stub player from the action and attaches the ban', () => {
+		const summary = importTxAdmin(db, data);
+
+		const players = db.select().from(schema.players).all();
+		expect(players).toHaveLength(1);
+		expect(players[0].name).toBe('GhostBanned');
+		expect(summary.stubPlayers).toBe(1);
+
+		const ids = db.select().from(schema.playerIdentifiers).all();
+		expect(ids).toHaveLength(1);
+		expect(ids[0].value).toBe('orphan');
+
+		const bans = db.select().from(schema.bans).all();
+		expect(bans[0].playerId).toBe(players[0].id);
+	});
+
+	it('reuses the same stub player for two actions sharing an identifier', () => {
+		importTxAdmin(db, {
+			...data,
+			actions: [
+				...data.actions,
+				{
+					type: 'warn',
+					reason: 'second',
+					identifiers: [{ type: 'license', value: 'orphan' }],
+					playerName: 'GhostBanned',
+					createdAt: new Date(1775855700 * 1000),
+					expiresAt: null,
+					revokedAt: null,
+					acked: false,
+				},
+			],
+		});
+
+		expect(db.select().from(schema.players).all()).toHaveLength(1);
+		expect(db.select().from(schema.bans).all()).toHaveLength(1);
+		expect(db.select().from(schema.warns).all()).toHaveLength(1);
+	});
+});
+
+describe('importTxAdmin - ban fields', () => {
+	function banWith(overrides: Partial<TxAdminImport['actions'][number]>) {
+		const localDb = freshDb();
+		const data: TxAdminImport = {
+			...emptyImport(),
+			actions: [
+				{
+					type: 'ban',
+					reason: 'r',
+					identifiers: [{ type: 'license', value: 'x' }],
+					playerName: 'X',
+					createdAt: new Date(1000 * 1000),
+					expiresAt: null,
+					revokedAt: null,
+					acked: false,
+					...overrides,
+				},
+			],
+		};
+		importTxAdmin(localDb, data);
+		return localDb.select().from(schema.bans).all()[0];
+	}
+
+	it('stores a permanent ban with null expiresAt', () => {
+		expect(banWith({ expiresAt: null }).expiresAt).toBeNull();
+	});
+
+	it('stores a temporary ban expiry', () => {
+		const expires = new Date(1800000000 * 1000);
+		expect(banWith({ expiresAt: expires }).expiresAt).toEqual(expires);
+	});
+
+	it('stores the revocation timestamp', () => {
+		const revoked = new Date(1777152610 * 1000);
+		expect(banWith({ revokedAt: revoked }).revokedAt).toEqual(revoked);
+	});
+});
+
+describe('importTxAdmin - warn fields', () => {
+	function warnWith(overrides: Partial<TxAdminImport['actions'][number]>) {
+		const localDb = freshDb();
+		const data: TxAdminImport = {
+			...emptyImport(),
+			actions: [
+				{
+					type: 'warn',
+					reason: 'r',
+					identifiers: [{ type: 'license', value: 'x' }],
+					playerName: 'X',
+					createdAt: new Date(1000 * 1000),
+					expiresAt: null,
+					revokedAt: null,
+					acked: false,
+					...overrides,
+				},
+			],
+		};
+		importTxAdmin(localDb, data);
+		return localDb.select().from(schema.warns).all()[0];
+	}
+
+	it('marks an acked warn as read', () => {
+		expect(warnWith({ acked: true }).read).toBe(1);
+		expect(warnWith({ acked: false }).read).toBe(0);
+	});
+
+	it('marks a revoked warn as revoked', () => {
+		expect(warnWith({ revokedAt: new Date(2000 * 1000) }).revoked).toBe(1);
+		expect(warnWith({ revokedAt: null }).revoked).toBe(0);
+	});
+
+	it('uses createdAt as the warn issuedAt', () => {
+		expect(warnWith({ createdAt: new Date(1234 * 1000) }).issuedAt).toEqual(
+			new Date(1234 * 1000),
+		);
+	});
+});
+
+describe('importTxAdmin - action idempotency', () => {
+	const data: TxAdminImport = {
+		...emptyImport(),
+		actions: [
+			{
+				type: 'ban',
+				reason: 'dupe-check',
+				identifiers: [{ type: 'license', value: 'abc' }],
+				playerName: 'P',
+				createdAt: new Date(1775855632 * 1000),
+				expiresAt: null,
+				revokedAt: null,
+				acked: false,
+			},
+		],
+	};
+
+	it('does not duplicate bans on re-run', () => {
+		importTxAdmin(db, data);
+		const summary = importTxAdmin(db, data);
+
+		expect(db.select().from(schema.bans).all()).toHaveLength(1);
+		expect(summary.bans.created).toBe(0);
+		expect(summary.bans.skipped).toBe(1);
+	});
+});
+
+describe('importTxAdmin - whitelist', () => {
+	const data: TxAdminImport = {
+		...emptyImport(),
+		whitelist: [
+			{ type: 'license', value: 'wl1', addedAt: new Date(1000 * 1000) },
+			{ type: 'discord', value: 'wl2', addedAt: new Date(2000 * 1000) },
+		],
+	};
+
+	it('imports whitelist entries as system entries', () => {
+		const summary = importTxAdmin(db, data);
+
+		const wl = db.select().from(schema.whitelistedIdentifers).all();
+		expect(wl).toHaveLength(2);
+		expect(wl.every((w) => w.system === 1)).toBe(true);
+		expect(wl.every((w) => w.adminId === null)).toBe(true);
+		expect(summary.whitelist.created).toBe(2);
+	});
+
+	it('is idempotent for whitelist entries', () => {
+		importTxAdmin(db, data);
+		const summary = importTxAdmin(db, data);
+
+		expect(db.select().from(schema.whitelistedIdentifers).all()).toHaveLength(2);
+		expect(summary.whitelist.created).toBe(0);
+	});
+});
+
+describe('importTxAdmin - shared identifiers across players', () => {
+	it('does not crash when two import players share an identifier', () => {
+		const data: TxAdminImport = {
+			...emptyImport(),
+			players: [
+				{
+					name: 'A',
+					playtime: 0,
+					firstSeen: new Date(0),
+					lastSeen: new Date(0),
+					identifiers: [{ type: 'license', value: 'shared' }],
+					note: null,
+				},
+				{
+					name: 'B',
+					playtime: 0,
+					firstSeen: new Date(0),
+					lastSeen: new Date(0),
+					identifiers: [{ type: 'license', value: 'shared' }],
+					note: null,
+				},
+			],
+		};
+
+		expect(() => importTxAdmin(db, data)).not.toThrow();
+
+		const ids = db
+			.select()
+			.from(schema.playerIdentifiers)
+			.where(eq(schema.playerIdentifiers.value, 'shared'))
+			.all();
+		expect(ids).toHaveLength(1);
+	});
+});

--- a/packages/database/src/import/txadmin.importer.ts
+++ b/packages/database/src/import/txadmin.importer.ts
@@ -1,0 +1,251 @@
+import { and, eq, inArray } from 'drizzle-orm';
+import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import * as schema from '../schema';
+import type {
+	ImportAction,
+	ImportPlayer,
+	TxAdminIdentifier,
+	TxAdminImport,
+} from './txadmin';
+
+type DB = BunSQLiteDatabase<typeof schema>;
+type Tx = Parameters<Parameters<DB['transaction']>[0]>[0];
+
+export interface ImportSummary {
+	players: { created: number; matched: number };
+	identifiers: { created: number };
+	notes: { created: number };
+	bans: { created: number; skipped: number };
+	warns: { created: number; skipped: number };
+	stubPlayers: number;
+	whitelist: { created: number };
+}
+
+function emptySummary(): ImportSummary {
+	return {
+		players: { created: 0, matched: 0 },
+		identifiers: { created: 0 },
+		notes: { created: 0 },
+		bans: { created: 0, skipped: 0 },
+		warns: { created: 0, skipped: 0 },
+		stubPlayers: 0,
+		whitelist: { created: 0 },
+	};
+}
+
+const { players, playerIdentifiers, playerNotes, bans, warns } = schema;
+const whitelist = schema.whitelistedIdentifers;
+
+function findPlayerId(tx: Tx, identifiers: TxAdminIdentifier[]): number | null {
+	const values = identifiers.map((i) => i.value);
+	if (values.length === 0) return null;
+
+	const row = tx
+		.select({ playerId: playerIdentifiers.playerId })
+		.from(playerIdentifiers)
+		.where(inArray(playerIdentifiers.value, values))
+		.limit(1)
+		.get();
+
+	return row?.playerId ?? null;
+}
+
+function insertIdentifiers(
+	tx: Tx,
+	playerId: number,
+	identifiers: TxAdminIdentifier[],
+): number {
+	if (identifiers.length === 0) return 0;
+
+	const inserted = tx
+		.insert(playerIdentifiers)
+		.values(identifiers.map((i) => ({ ...i, playerId })))
+		.onConflictDoNothing()
+		.returning()
+		.all();
+
+	return inserted.length;
+}
+
+function importPlayer(
+	tx: Tx,
+	player: ImportPlayer,
+	summary: ImportSummary,
+): number {
+	const existingId = findPlayerId(tx, player.identifiers);
+
+	let playerId: number;
+	if (existingId !== null) {
+		summary.players.matched++;
+		playerId = existingId;
+	} else {
+		const row = tx
+			.insert(players)
+			.values({
+				name: player.name,
+				playtime: player.playtime,
+				firstSeen: player.firstSeen,
+				lastSeen: player.lastSeen,
+			})
+			.returning()
+			.get();
+		summary.players.created++;
+		playerId = row.id;
+	}
+
+	summary.identifiers.created += insertIdentifiers(
+		tx,
+		playerId,
+		player.identifiers,
+	);
+
+	if (player.note) {
+		const existingNote = tx
+			.select({ id: playerNotes.id })
+			.from(playerNotes)
+			.where(
+				and(
+					eq(playerNotes.playerId, playerId),
+					eq(playerNotes.content, player.note.content),
+				),
+			)
+			.get();
+
+		if (!existingNote) {
+			tx.insert(playerNotes)
+				.values({
+					playerId,
+					content: player.note.content,
+					issuer: null,
+					issuedAt: player.note.issuedAt,
+				})
+				.run();
+			summary.notes.created++;
+		}
+	}
+
+	return playerId;
+}
+
+function resolveActionPlayer(
+	tx: Tx,
+	action: ImportAction,
+	summary: ImportSummary,
+): number {
+	const existingId = findPlayerId(tx, action.identifiers);
+	if (existingId !== null) return existingId;
+
+	const row = tx
+		.insert(players)
+		.values({
+			name: action.playerName,
+			playtime: 0,
+			firstSeen: action.createdAt,
+			lastSeen: action.createdAt,
+		})
+		.returning()
+		.get();
+
+	insertIdentifiers(tx, row.id, action.identifiers);
+	summary.stubPlayers++;
+
+	return row.id;
+}
+
+function importAction(tx: Tx, action: ImportAction, summary: ImportSummary) {
+	const playerId = resolveActionPlayer(tx, action, summary);
+
+	if (action.type === 'ban') {
+		const existing = tx
+			.select({ id: bans.id })
+			.from(bans)
+			.where(
+				and(
+					eq(bans.playerId, playerId),
+					eq(bans.createdAt, action.createdAt),
+					eq(bans.reason, action.reason),
+				),
+			)
+			.get();
+
+		if (existing) {
+			summary.bans.skipped++;
+			return;
+		}
+
+		tx.insert(bans)
+			.values({
+				playerId,
+				reason: action.reason,
+				issuer: null,
+				expiresAt: action.expiresAt,
+				createdAt: action.createdAt,
+				revokedAt: action.revokedAt,
+			})
+			.run();
+		summary.bans.created++;
+		return;
+	}
+
+	const existing = tx
+		.select({ id: warns.id })
+		.from(warns)
+		.where(
+			and(
+				eq(warns.playerId, playerId),
+				eq(warns.issuedAt, action.createdAt),
+				eq(warns.reason, action.reason),
+			),
+		)
+		.get();
+
+	if (existing) {
+		summary.warns.skipped++;
+		return;
+	}
+
+	tx.insert(warns)
+		.values({
+			playerId,
+			reason: action.reason,
+			issuer: null,
+			read: action.acked ? 1 : 0,
+			revoked: action.revokedAt ? 1 : 0,
+			issuedAt: action.createdAt,
+		})
+		.run();
+	summary.warns.created++;
+}
+
+export function importTxAdmin(db: DB, data: TxAdminImport): ImportSummary {
+	const summary = emptySummary();
+
+	db.transaction((tx) => {
+		for (const player of data.players) {
+			importPlayer(tx, player, summary);
+		}
+
+		for (const action of data.actions) {
+			importAction(tx, action, summary);
+		}
+
+		for (const entry of data.whitelist) {
+			const inserted = tx
+				.insert(whitelist)
+				.values({
+					type: entry.type,
+					value: entry.value,
+					adminId: null,
+					system: 1,
+					addedAt: entry.addedAt,
+				})
+				.onConflictDoNothing()
+				.returning()
+				.all();
+
+			summary.whitelist.created += inserted.length;
+		}
+	});
+
+	return summary;
+}

--- a/packages/database/src/import/txadmin.test.ts
+++ b/packages/database/src/import/txadmin.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it } from 'bun:test';
+import {
+	parseIdentifiers,
+	parseTxAdminDb,
+	transformAction,
+	transformPlayer,
+	transformWhitelistApproval,
+} from './txadmin';
+
+describe('parseIdentifiers', () => {
+	it('splits each "type:value" entry on the first colon', () => {
+		const result = parseIdentifiers([
+			'steam:1100001721ad022',
+			'license:64c013bfdecf4e66',
+			'discord:1216687964227112963',
+		]);
+
+		expect(result).toEqual([
+			{ type: 'steam', value: 'steam:1100001721ad022' },
+			{ type: 'license', value: 'license:64c013bfdecf4e66' },
+			{ type: 'discord', value: 'discord:1216687964227112963' },
+		]);
+	});
+
+	it('keeps license2 as a distinct identifier type', () => {
+		const result = parseIdentifiers([
+			'license:abc',
+			'license2:def',
+		]);
+
+		expect(result).toContainEqual({ type: 'license', value: 'license:abc' });
+		expect(result).toContainEqual({ type: 'license2', value: 'license2:def' });
+	});
+
+	it('skips malformed entries with no colon or empty value', () => {
+		const result = parseIdentifiers([
+			'garbage',
+			'license:',
+			'',
+			'steam:valid',
+		]);
+
+		expect(result).toEqual([{ type: 'steam', value: 'steam:valid' }]);
+	});
+
+	it('dedupes identical identifiers', () => {
+		const result = parseIdentifiers([
+			'license:abc',
+			'license:abc',
+		]);
+
+		expect(result).toEqual([{ type: 'license', value: 'license:abc' }]);
+	});
+
+	it('returns an empty array for non-array input', () => {
+		expect(parseIdentifiers(undefined as unknown as string[])).toEqual([]);
+	});
+});
+
+describe('transformPlayer', () => {
+	const raw = {
+		license: '8676b3a35bb772bd7de43df21079f3603ed3516d',
+		ids: [
+			'steam:11000012ee73e38',
+			'license:8676b3a35bb772bd7de43df21079f3603ed3516d',
+			'discord:481267231393841153',
+		],
+		hwids: ['3:abc'],
+		displayName: 'CaliChris',
+		pureName: 'calichris',
+		playTime: 24088,
+		tsLastConnection: 1781156576,
+		tsJoined: 1775845668,
+		notes: {
+			text: 'FRP 1st offense',
+			lastAdmin: 'Meli',
+			tsLastEdit: 1779553664,
+		},
+	};
+
+	it('uses displayName as the player name', () => {
+		expect(transformPlayer(raw).name).toBe('CaliChris');
+	});
+
+	it('converts playTime from minutes to milliseconds', () => {
+		expect(transformPlayer(raw).playtime).toBe(24088 * 60 * 1000);
+	});
+
+	it('converts tsJoined and tsLastConnection from unix seconds to Date', () => {
+		const player = transformPlayer(raw);
+		expect(player.firstSeen).toEqual(new Date(1775845668 * 1000));
+		expect(player.lastSeen).toEqual(new Date(1781156576 * 1000));
+	});
+
+	it('parses identifiers from the ids array', () => {
+		expect(transformPlayer(raw).identifiers).toContainEqual({
+			type: 'discord',
+			value: 'discord:481267231393841153',
+		});
+	});
+
+	it('maps notes.text to a note dated at tsLastEdit', () => {
+		const note = transformPlayer(raw).note;
+		expect(note?.content).toBe('FRP 1st offense');
+		expect(note?.issuedAt).toEqual(new Date(1779553664 * 1000));
+	});
+
+	it('returns a null note when the player has no notes', () => {
+		expect(transformPlayer({ ...raw, notes: undefined }).note).toBeNull();
+	});
+
+	it('returns a null note when the note text is empty', () => {
+		expect(
+			transformPlayer({ ...raw, notes: { text: '   ' } }).note,
+		).toBeNull();
+	});
+
+	it('falls back to pureName then "Unknown" when displayName is missing', () => {
+		expect(transformPlayer({ ...raw, displayName: '' }).name).toBe('calichris');
+		expect(
+			transformPlayer({ ...raw, displayName: '', pureName: '' }).name,
+		).toBe('Unknown');
+	});
+});
+
+describe('transformAction (ban)', () => {
+	const ban = {
+		id: 'BTQE-KAEW',
+		type: 'ban',
+		ids: ['license:64c013bf', 'discord:121668796'],
+		hwids: ['4:abc'],
+		playerName: 'rdool1',
+		reason: 'Cheating/ESP',
+		author: 'ethan',
+		timestamp: 1775855632,
+		expiration: false,
+		revocation: { timestamp: null, author: null },
+	};
+
+	it('marks the action type as ban', () => {
+		expect(transformAction(ban).type).toBe('ban');
+	});
+
+	it('maps timestamp to createdAt', () => {
+		expect(transformAction(ban).createdAt).toEqual(new Date(1775855632 * 1000));
+	});
+
+	it('treats expiration:false as a permanent ban (null expiresAt)', () => {
+		expect(transformAction(ban).expiresAt).toBeNull();
+	});
+
+	it('converts a numeric expiration to a Date', () => {
+		expect(transformAction({ ...ban, expiration: 1800000000 }).expiresAt).toEqual(
+			new Date(1800000000 * 1000),
+		);
+	});
+
+	it('leaves revokedAt null when not revoked', () => {
+		expect(transformAction(ban).revokedAt).toBeNull();
+	});
+
+	it('maps a revocation timestamp to revokedAt', () => {
+		const revoked = transformAction({
+			...ban,
+			revocation: { timestamp: 1777152610, author: 'izzykitty' },
+		});
+		expect(revoked.revokedAt).toEqual(new Date(1777152610 * 1000));
+	});
+
+	it('preserves the reason and player name', () => {
+		const result = transformAction(ban);
+		expect(result.reason).toBe('Cheating/ESP');
+		expect(result.playerName).toBe('rdool1');
+	});
+
+	it('falls back to a placeholder reason when missing', () => {
+		expect(transformAction({ ...ban, reason: '' }).reason).toBe(
+			'No reason provided',
+		);
+	});
+
+	it('parses identifiers used to match or create the player', () => {
+		expect(transformAction(ban).identifiers).toContainEqual({
+			type: 'license',
+			value: 'license:64c013bf',
+		});
+	});
+});
+
+describe('transformAction (warn)', () => {
+	const warn = {
+		id: 'WZYH-T3W5',
+		type: 'warn',
+		ids: ['license:059dff28', 'discord:147356975'],
+		hwids: [],
+		playerName: 'BoldBat8059',
+		reason: 'Change your outfit',
+		author: 'iceagent',
+		timestamp: 1775873614,
+		expiration: false,
+		acked: true,
+		revocation: { timestamp: null, author: null },
+	};
+
+	it('marks the action type as warn', () => {
+		expect(transformAction(warn).type).toBe('warn');
+	});
+
+	it('reflects the acked flag', () => {
+		expect(transformAction(warn).acked).toBe(true);
+		expect(transformAction({ ...warn, acked: false }).acked).toBe(false);
+	});
+
+	it('defaults acked to false when the flag is absent', () => {
+		expect(transformAction({ ...warn, acked: undefined }).acked).toBe(false);
+	});
+});
+
+describe('transformWhitelistApproval', () => {
+	it('parses the identifier string into a typed whitelist entry', () => {
+		const result = transformWhitelistApproval({
+			id: 'license:abc123',
+			playerName: 'Someone',
+			tsApproved: 1775855632,
+			approvedBy: 'admin',
+		});
+
+		expect(result).toEqual({
+			type: 'license',
+			value: 'license:abc123',
+			addedAt: new Date(1775855632 * 1000),
+		});
+	});
+
+	it('returns null for an unparseable identifier', () => {
+		expect(
+			transformWhitelistApproval({ id: 'garbage', tsApproved: 1 }),
+		).toBeNull();
+	});
+});
+
+describe('parseTxAdminDb', () => {
+	const db = {
+		version: 5,
+		players: [
+			{
+				license: 'abc',
+				ids: ['license:abc'],
+				displayName: 'P1',
+				playTime: 10,
+				tsJoined: 1775845668,
+				tsLastConnection: 1781156576,
+			},
+		],
+		actions: [
+			{
+				id: 'X',
+				type: 'ban',
+				ids: ['license:abc'],
+				playerName: 'P1',
+				reason: 'r',
+				author: 'a',
+				timestamp: 1775855632,
+				expiration: false,
+				revocation: { timestamp: null, author: null },
+			},
+		],
+		whitelistApprovals: [
+			{ id: 'discord:999', tsApproved: 1775855632, approvedBy: 'a' },
+		],
+		whitelistRequests: [],
+	};
+
+	it('returns normalized players, actions and whitelist arrays', () => {
+		const result = parseTxAdminDb(db);
+		expect(result.players).toHaveLength(1);
+		expect(result.actions).toHaveLength(1);
+		expect(result.whitelist).toHaveLength(1);
+		expect(result.players[0].name).toBe('P1');
+		expect(result.whitelist[0]).toEqual({
+			type: 'discord',
+			value: 'discord:999',
+			addedAt: new Date(1775855632 * 1000),
+		});
+	});
+
+	it('tolerates missing whitelist arrays', () => {
+		const result = parseTxAdminDb({ ...db, whitelistApprovals: undefined });
+		expect(result.whitelist).toEqual([]);
+	});
+
+	it('skips unparseable whitelist approvals', () => {
+		const result = parseTxAdminDb({
+			...db,
+			whitelistApprovals: [{ id: 'garbage', tsApproved: 1 }],
+		});
+		expect(result.whitelist).toEqual([]);
+	});
+
+	it('throws when given a non-object', () => {
+		expect(() => parseTxAdminDb(null)).toThrow('invalid_txadmin_db');
+		expect(() => parseTxAdminDb('nope')).toThrow('invalid_txadmin_db');
+	});
+
+	it('throws when players is not an array', () => {
+		expect(() => parseTxAdminDb({ version: 5, actions: [] })).toThrow(
+			'invalid_txadmin_db',
+		);
+	});
+
+	it('throws when actions is not an array', () => {
+		expect(() => parseTxAdminDb({ version: 5, players: [] })).toThrow(
+			'invalid_txadmin_db',
+		);
+	});
+});

--- a/packages/database/src/import/txadmin.ts
+++ b/packages/database/src/import/txadmin.ts
@@ -1,0 +1,192 @@
+// region types
+
+export interface TxAdminIdentifier {
+	type: string;
+	value: string;
+}
+
+export interface ImportPlayerNote {
+	content: string;
+	issuedAt: Date;
+}
+
+export interface ImportPlayer {
+	name: string;
+	playtime: number;
+	firstSeen: Date;
+	lastSeen: Date;
+	identifiers: TxAdminIdentifier[];
+	note: ImportPlayerNote | null;
+}
+
+export interface ImportAction {
+	type: 'ban' | 'warn';
+	reason: string;
+	identifiers: TxAdminIdentifier[];
+	playerName: string;
+	createdAt: Date;
+	expiresAt: Date | null;
+	revokedAt: Date | null;
+	acked: boolean;
+}
+
+export interface ImportWhitelist {
+	type: string;
+	value: string;
+	addedAt: Date;
+}
+
+export interface TxAdminImport {
+	players: ImportPlayer[];
+	actions: ImportAction[];
+	whitelist: ImportWhitelist[];
+}
+
+// region raw input shapes (txAdmin playersDB.json v5)
+
+interface RawTxNote {
+	text?: string;
+	lastAdmin?: string;
+	tsLastEdit?: number;
+}
+
+interface RawTxPlayer {
+	ids?: string[];
+	displayName?: string;
+	pureName?: string;
+	playTime?: number;
+	tsJoined?: number;
+	tsLastConnection?: number;
+	notes?: RawTxNote;
+}
+
+interface RawTxRevocation {
+	timestamp?: number | null;
+	author?: string | null;
+}
+
+interface RawTxAction {
+	type?: string;
+	ids?: string[];
+	playerName?: string;
+	reason?: string;
+	timestamp?: number;
+	expiration?: number | boolean;
+	acked?: boolean;
+	revocation?: RawTxRevocation;
+}
+
+interface RawTxApproval {
+	id?: string;
+	tsApproved?: number;
+	playerName?: string;
+	approvedBy?: string;
+}
+
+// region helpers
+
+const secondsToDate = (seconds: number | undefined | null): Date =>
+	new Date((seconds ?? 0) * 1000);
+
+// region transformers
+
+export function parseIdentifiers(ids: string[]): TxAdminIdentifier[] {
+	if (!Array.isArray(ids)) return [];
+
+	const seen = new Set<string>();
+	const result: TxAdminIdentifier[] = [];
+
+	for (const entry of ids) {
+		if (typeof entry !== 'string') continue;
+
+		const colon = entry.indexOf(':');
+		if (colon <= 0) continue;
+
+		const type = entry.slice(0, colon);
+		if (!entry.slice(colon + 1)) continue;
+
+		if (seen.has(entry)) continue;
+
+		seen.add(entry);
+		result.push({ type, value: entry });
+	}
+
+	return result;
+}
+
+export function transformPlayer(raw: RawTxPlayer): ImportPlayer {
+	const name = raw.displayName?.trim() || raw.pureName?.trim() || 'Unknown';
+
+	const noteText = raw.notes?.text?.trim();
+	const note: ImportPlayerNote | null = noteText
+		? { content: noteText, issuedAt: secondsToDate(raw.notes?.tsLastEdit) }
+		: null;
+
+	return {
+		name,
+		playtime: (raw.playTime ?? 0) * 60 * 1000,
+		firstSeen: secondsToDate(raw.tsJoined),
+		lastSeen: secondsToDate(raw.tsLastConnection),
+		identifiers: parseIdentifiers(raw.ids as string[]),
+		note,
+	};
+}
+
+export function transformAction(raw: RawTxAction): ImportAction {
+	const type: 'ban' | 'warn' = raw.type === 'warn' ? 'warn' : 'ban';
+
+	return {
+		type,
+		reason: raw.reason?.trim() || 'No reason provided',
+		identifiers: parseIdentifiers(raw.ids as string[]),
+		playerName: raw.playerName?.trim() || 'Unknown',
+		createdAt: secondsToDate(raw.timestamp),
+		expiresAt:
+			typeof raw.expiration === 'number' ? secondsToDate(raw.expiration) : null,
+		revokedAt: raw.revocation?.timestamp
+			? secondsToDate(raw.revocation.timestamp)
+			: null,
+		acked: raw.acked === true,
+	};
+}
+
+export function transformWhitelistApproval(
+	raw: RawTxApproval,
+): ImportWhitelist | null {
+	const [identifier] = parseIdentifiers([raw.id as string]);
+	if (!identifier) return null;
+
+	return {
+		type: identifier.type,
+		value: identifier.value,
+		addedAt: secondsToDate(raw.tsApproved),
+	};
+}
+
+export function parseTxAdminDb(raw: unknown): TxAdminImport {
+	if (!raw || typeof raw !== 'object') {
+		throw new Error('invalid_txadmin_db');
+	}
+
+	const db = raw as {
+		players?: unknown;
+		actions?: unknown;
+		whitelistApprovals?: unknown;
+	};
+
+	if (!Array.isArray(db.players) || !Array.isArray(db.actions)) {
+		throw new Error('invalid_txadmin_db');
+	}
+
+	const approvals = Array.isArray(db.whitelistApprovals)
+		? db.whitelistApprovals
+		: [];
+
+	return {
+		players: db.players.map(transformPlayer),
+		actions: db.actions.map(transformAction),
+		whitelist: approvals
+			.map(transformWhitelistApproval)
+			.filter((entry): entry is ImportWhitelist => entry !== null),
+	};
+}

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -13,8 +13,10 @@ import { createApiTokensRepository } from './repositories/api-tokens';
 import { createAuthRepository } from './repositories/auth';
 import { createAdminsRepository } from './repositories/admins';
 import { createWhitelistRepository } from './repositories/whitelist';
+import { createMigrateRepository } from './repositories/migrate';
 
 export type { Migration } from './migrations/types';
+export type { ImportSummary } from './import/txadmin.importer';
 
 // region initialise
 
@@ -77,4 +79,5 @@ export const repo = {
 	auth: createAuthRepository(db),
 	admins: createAdminsRepository(db),
 	whitelist: createWhitelistRepository(db),
+	migrate: createMigrateRepository(db),
 };

--- a/packages/database/src/repositories/migrate.test.ts
+++ b/packages/database/src/repositories/migrate.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { drizzle, type BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import * as schema from '../schema';
+import { migrations, runMigrations } from '../migrations';
+import { createMigrateRepository } from './migrate';
+
+type DB = BunSQLiteDatabase<typeof schema>;
+
+function freshDb(): DB {
+	const sqlite = new Database(':memory:');
+	sqlite.run('PRAGMA foreign_keys = ON;');
+	const log = console.log;
+	console.log = () => {};
+	runMigrations(sqlite, migrations);
+	console.log = log;
+	return drizzle(sqlite, { schema });
+}
+
+const rawDb = {
+	version: 5,
+	players: [
+		{
+			license: 'abc',
+			ids: ['license:abc', 'discord:123'],
+			displayName: 'Player One',
+			playTime: 10,
+			tsJoined: 1775845668,
+			tsLastConnection: 1781156576,
+			notes: { text: 'a note', tsLastEdit: 1779553664 },
+		},
+	],
+	actions: [
+		{
+			id: 'BAN1',
+			type: 'ban',
+			ids: ['license:orphan'],
+			playerName: 'OnSight',
+			reason: 'cheating',
+			author: 'admin',
+			timestamp: 1775855632,
+			expiration: false,
+			revocation: { timestamp: null, author: null },
+		},
+	],
+	whitelistApprovals: [
+		{ id: 'discord:999', tsApproved: 1775855632, approvedBy: 'admin' },
+	],
+	whitelistRequests: [],
+};
+
+describe('repo.migrate.fromTxAdmin', () => {
+	it('parses raw txAdmin json, imports it, and returns a summary', () => {
+		const db = freshDb();
+		const repo = createMigrateRepository(db);
+
+		const summary = repo.fromTxAdmin(rawDb);
+
+		expect(summary.players.created).toBe(1);
+		expect(summary.stubPlayers).toBe(1);
+		expect(summary.bans.created).toBe(1);
+		expect(summary.notes.created).toBe(1);
+		expect(summary.whitelist.created).toBe(1);
+
+		expect(db.select().from(schema.players).all()).toHaveLength(2);
+		expect(db.select().from(schema.bans).all()).toHaveLength(1);
+		expect(db.select().from(schema.whitelistedIdentifers).all()).toHaveLength(1);
+
+		const storedIds = db
+			.select()
+			.from(schema.playerIdentifiers)
+			.all()
+			.map((i) => i.value);
+		expect(storedIds).toContain('license:abc');
+		expect(storedIds).toContain('discord:123');
+		expect(storedIds).toContain('license:orphan');
+
+		const wl = db.select().from(schema.whitelistedIdentifers).all();
+		expect(wl[0].value).toBe('discord:999');
+	});
+
+	it('is idempotent across runs', () => {
+		const db = freshDb();
+		const repo = createMigrateRepository(db);
+
+		repo.fromTxAdmin(rawDb);
+		const second = repo.fromTxAdmin(rawDb);
+
+		expect(second.players.created).toBe(0);
+		expect(second.bans.created).toBe(0);
+		expect(db.select().from(schema.players).all()).toHaveLength(2);
+	});
+
+	it('throws invalid_txadmin_db for malformed input', () => {
+		const repo = createMigrateRepository(freshDb());
+		expect(() => repo.fromTxAdmin(null)).toThrow('invalid_txadmin_db');
+		expect(() => repo.fromTxAdmin({ players: 'nope' })).toThrow(
+			'invalid_txadmin_db',
+		);
+	});
+});

--- a/packages/database/src/repositories/migrate.ts
+++ b/packages/database/src/repositories/migrate.ts
@@ -1,0 +1,19 @@
+import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import type * as schema from '../schema';
+import { parseTxAdminDb } from '../import/txadmin';
+import { importTxAdmin, type ImportSummary } from '../import/txadmin.importer';
+
+type DB = BunSQLiteDatabase<typeof schema>;
+
+class MigrateRepository {
+	constructor(private readonly db: DB) {}
+
+	fromTxAdmin(raw: unknown): ImportSummary {
+		const parsed = parseTxAdminDb(raw);
+		return importTxAdmin(this.db, parsed);
+	}
+}
+
+export function createMigrateRepository(db: DB) {
+	return new MigrateRepository(db);
+}

--- a/packages/shared/src/constants/audit.ts
+++ b/packages/shared/src/constants/audit.ts
@@ -11,4 +11,5 @@ export const AUDIT_LOG_ACTIONS = {
 	ADMIN: ['admin.create', 'admin.delete', 'admin.update'],
 	REPORT: ['report.close', 'report.join'],
 	SETTINGS: ['settings.update'],
+	MIGRATE: ['migrate.txadmin'],
 } as const;


### PR DESCRIPTION
## Description
Add a MASTER-only POST /api/migrate endpoint that ingests a txAdmin playersDB.json and imports players, identifiers, notes, bans, warns and whitelist approvals. Matching is by full identifier, so the import is idempotent and safe to re-run.
The import runs in a re-exec'd child process the parent pipes the raw JSON in and reads the summary back so a multi-MB migration never blocks the core event loop. Logged as migrate.txadmin in the audit trail.

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [x] Builds & runs on Windows
- [x] Builds & runs on Linux

---

## Additional Notes
I tried using a normal worker, however that wasn't quite feasible due to the fact that a .exe already bundles all of our modules and cant contain a worker on top of it.

So having the bun child process was the second best thing IMO.