### PR TITLE
Tweak: audit log row display

### DIFF
--- a/apps/webpanel/src/pages/settings/adminview.tsx
+++ b/apps/webpanel/src/pages/settings/adminview.tsx
@@ -59,6 +59,7 @@ import {
 	type LucidIconName,
 } from '@fxmanager/ui/components/dynamic-icon';
 import { PlayerSearch } from './components/player-search';
+import { AuditLogRow } from './components/auditlog-row';
 
 function LoadingSkeleton() {
 	return (
@@ -376,43 +377,7 @@ export default function AdminView() {
 										<div className="">
 											{adminData.auditLogs.length > 0 ? (
 												adminData.auditLogs.map((log) => (
-													<div
-														key={log.id}
-														className="flex justify-between items-start border-b py-3 last:border-0 hover:bg-muted/20 transition-colors mr-4"
-													>
-														<div className="space-y-1">
-															<div className="flex items-center gap-2">
-																<span className="text-sm font-semibold uppercase tracking-wide">
-																	{log.action.replace('_', ' ')}
-																</span>
-																{log.player && (
-																	<>
-																		<span className="text-muted-foreground text-xs">
-																			→
-																		</span>
-																		<span className="text-xs font-mono bg-secondary px-1.5 py-0.5 rounded text-secondary-foreground">
-																			{log.player}
-																		</span>
-																	</>
-																)}
-															</div>
-
-															{log.metadata &&
-																Object.keys(log.metadata).length > 0 && (
-																	<p className="text-xs text-muted-foreground italic">
-																		{Object.entries(log.metadata)
-																			.map(([key, val]) => `${key}: ${val}`)
-																			.join(' | ')}
-																	</p>
-																)}
-														</div>
-
-														<div className="flex flex-col justify-center items-end gap-1 self-stretch">
-															<span className="text-xs text-muted-foreground">
-																{formatDate(log.createdAt)}
-															</span>
-														</div>
-													</div>
+													<AuditLogRow key={log.id} log={log} />
 												))
 											) : (
 												<div className="flex flex-col items-center justify-center py-8 px-4 border-2 border-dashed rounded-lg bg-muted/30">

--- a/apps/webpanel/src/pages/settings/auditlogs.tsx
+++ b/apps/webpanel/src/pages/settings/auditlogs.tsx
@@ -1,6 +1,8 @@
 import {
 	Calendar as CalendarIcon,
+	ChevronDown,
 	ChevronsUpDown,
+	ChevronUp,
 	Cog,
 	FileQuestion,
 	Info,
@@ -59,6 +61,134 @@ const ACTION_ICON_MAP: Record<
 
 type AdminItem = { id: number; username: string };
 
+function AuditLogRow({ log }: { log: AuditLog }) {
+	const [isExpanded, setIsExpanded] = useState(false);
+
+	const group = log.action.split('.')[0] || '';
+	const ActionIcon = ACTION_ICON_MAP[group] || FileQuestion;
+
+	const hasObjectData = log.metadata
+		? Object.values(log.metadata).some(
+				(val) => typeof val === 'object' && val !== null,
+			)
+		: false;
+
+	return (
+		<div className="grid grid-cols-[24px_1fr_180px_130px] items-start gap-4 py-3.5 px-2 hover:bg-muted/30 transition-colors border-b last:border-0">
+			<ActionIcon className="h-4 w-4 text-muted-foreground/70 mt-1" />
+
+			<div className="space-y-1.5 min-w-0">
+				<div className="flex flex-wrap items-center gap-2">
+					<span className="text-xs font-semibold uppercase tracking-wider text-foreground">
+						{log.action.replace('_', ' ').replace('.', ': ')}
+					</span>
+
+					{log.player && (
+						<span className="text-xs font-mono bg-muted border border-border/80 text-muted-foreground px-2 py-0.5 rounded">
+							target: {log.player} (#{log.playerId})
+						</span>
+					)}
+				</div>
+
+				{log.metadata && Object.keys(log.metadata).length > 0 && (
+					<div className="text-xs">
+						{hasObjectData ? (
+							<div className="space-y-2 mt-1">
+								<Button
+									type="button"
+									variant="outline"
+									onClick={() => setIsExpanded(!isExpanded)}
+									className="h-6 gap-1.5 px-2 text-[11px] font-semibold cursor-pointer"
+								>
+									<span>{isExpanded ? 'Hide Metadata' : 'View Metadata'}</span>
+									{isExpanded ? (
+										<ChevronUp className="h-3 w-3 opacity-70" />
+									) : (
+										<ChevronDown className="h-3 w-3 opacity-70" />
+									)}
+								</Button>
+
+								{isExpanded && (
+									<div className="col-span-full flex flex-row w-full gap-4 bg-muted/30 border border-border/50 rounded-lg p-3 mt-1">
+										{Object.entries(log.metadata).map(([key, val]) => (
+											<div
+												key={key}
+												className="flex flex-col flex-1 gap-0.5 border-r border-border/40 last:border-0 pr-4 last:pr-0 pb-0"
+											>
+												<span className="font-semibold text-foreground/70 text-[11px] uppercase tracking-wider">
+													{key}
+												</span>
+												<span className="font-mono text-muted-foreground text-xs">
+													{typeof val === 'object' && val !== null ? (
+														<ul className="space-y-1 list-disc pl-4 mt-1">
+															{Object.entries(val).map(
+																([nestedKey, nestedVal]) => (
+																	<li
+																		key={nestedKey}
+																		className="text-muted-foreground/40"
+																	>
+																		<div className="inline-flex items-start gap-1 text-muted-foreground">
+																			<span className="text-muted-foreground/70 font-semibold shrink-0">
+																				{nestedKey}:
+																			</span>
+																			<span className="text-foreground">
+																				{typeof nestedVal === 'object' &&
+																				nestedVal !== null
+																					? JSON.stringify(nestedVal)
+																					: String(nestedVal)}
+																			</span>
+																		</div>
+																	</li>
+																),
+															)}
+														</ul>
+													) : (
+														String(val)
+													)}
+												</span>
+											</div>
+										))}
+									</div>
+								)}
+							</div>
+						) : (
+							<div className="flex flex-wrap gap-x-3 gap-y-1 text-muted-foreground/80 font-medium">
+								{Object.entries(log.metadata).map(([key, val]) => (
+									<span key={key} className="inline-block">
+										<span className="text-muted-foreground/50">{key}:</span>{' '}
+										{String(val)}
+									</span>
+								))}
+							</div>
+						)}
+					</div>
+				)}
+			</div>
+
+			<div className="text-sm mt-0.5">
+				{log.adminId ? (
+					<Link
+						to={`/settings/admins/${log.adminId}`}
+						className="inline-flex items-center text-xs font-medium text-primary-foreground hover:underline bg-primary/40 px-2.5 py-1 rounded-md border"
+					>
+						{log.admin ?? `Admin #${log.adminId}`}
+					</Link>
+				) : (
+					<span className="text-xs font-medium text-muted-foreground bg-muted/60 px-2.5 py-1 rounded-md border border-border">
+						System
+					</span>
+				)}
+			</div>
+
+			<div className="text-right mt-1">
+				<span className="text-xs text-muted-foreground font-medium whitespace-nowrap">
+					{formatDate(log.createdAt)}
+				</span>
+			</div>
+		</div>
+	);
+}
+
 export default function AuditLogPage() {
 	const [auditLogs, setAuditLogs] = useState<AuditLog[]>([]);
 	const [isLoading, setIsLoading] = useState(true);
@@ -76,7 +206,7 @@ export default function AuditLogPage() {
 	const [dateRange, setDateRange] = useState<DateRange | undefined>(undefined);
 
 	const debouncedTarget = useDebounce(target, 400);
-	const debouncedadmin = useDebounce(target, 400);
+	const debouncedadmin = useDebounce(admin, 400);
 
 	useEffect(() => {
 		setIsLoading(true);
@@ -175,7 +305,7 @@ export default function AuditLogPage() {
 			/>
 
 			<div className="flex flex-wrap justify-between items-end border-b border-border/60 pb-4">
-				<div className="flex flex-wrap items-end gap-4 ">
+				<div className="flex flex-wrap items-end gap-4">
 					<div className="flex flex-col gap-1.5">
 						<Label className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
 							Search Target
@@ -385,6 +515,7 @@ export default function AuditLogPage() {
 					onClick={() => {
 						setTarget('');
 						setSelectedActions([]);
+						setSelectedAdmins([]);
 						setDateRange(undefined);
 						setPage(1);
 					}}
@@ -402,67 +533,10 @@ export default function AuditLogPage() {
 					</div>
 				) : auditLogs.length > 0 ? (
 					<div className="divide-y divide-border">
-						{auditLogs.map((log) => {
-							const group = log.action.split('.')[0] || '';
-							const ActionIcon = ACTION_ICON_MAP[group] || FileQuestion;
-
-							return (
-								<div
-									key={log.id}
-									className="grid grid-cols-[24px_1fr_180px_130px] items-center gap-4 py-3.5 px-2 hover:bg-muted/30 transition-colors"
-								>
-									<ActionIcon className="h-4 w-4 text-muted-foreground/70" />
-
-									<div className="space-y-1.5 min-w-0">
-										<div className="flex flex-wrap items-center gap-2">
-											<span className="text-xs font-semibold uppercase tracking-wider text-foreground">
-												{log.action.replace('_', ' ').replace('.', ': ')}
-											</span>
-
-											{log.player && (
-												<span className="text-xs font-mono bg-muted border border-border/80 text-muted-foreground px-2 py-0.5 rounded">
-													target: {log.player} (#{log.playerId})
-												</span>
-											)}
-										</div>
-
-										{log.metadata && Object.keys(log.metadata).length > 0 && (
-											<div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground/80 font-medium">
-												{Object.entries(log.metadata).map(([key, val]) => (
-													<span key={key} className="inline-block">
-														<span className="text-muted-foreground/50">
-															{key}:
-														</span>{' '}
-														{String(val)}
-													</span>
-												))}
-											</div>
-										)}
-									</div>
-
-									<div className="text-sm">
-										{log.adminId ? (
-											<Link
-												to={`/settings/admins/${log.adminId}`}
-												className="inline-flex items-center text-xs font-medium text-primary-foreground hover:underline bg-primary/40 px-2.5 py-1 rounded-md border"
-											>
-												{log.admin ?? `Admin #${log.adminId}`}
-											</Link>
-										) : (
-											<span className="text-xs font-medium text-muted-foreground bg-muted/60 px-2.5 py-1 rounded-md border border-border">
-												System
-											</span>
-										)}
-									</div>
-
-									<div className="text-right">
-										<span className="text-xs text-muted-foreground font-medium whitespace-nowrap">
-											{formatDate(log.createdAt)}
-										</span>
-									</div>
-								</div>
-							);
-						})}
+						{/* Fix: Cleaned up the nested mapping issue completely */}
+						{auditLogs.map((log) => (
+							<AuditLogRow key={log.id} log={log} />
+						))}
 					</div>
 				) : (
 					<div className="flex flex-col items-center justify-center py-16 px-4 border-2 border-dashed rounded-xl bg-muted/20">

--- a/apps/webpanel/src/pages/settings/auditlogs.tsx
+++ b/apps/webpanel/src/pages/settings/auditlogs.tsx
@@ -1,27 +1,16 @@
 import {
 	Calendar as CalendarIcon,
-	ChevronDown,
 	ChevronsUpDown,
-	ChevronUp,
-	Cog,
-	FileQuestion,
 	Info,
-	MessagesSquare,
-	ScanEye,
 	ScrollText,
-	Server,
-	Shield,
-	User,
 	X,
 } from 'lucide-react';
 import { PageHeader } from '@/components/page-header';
 import { ScrollArea } from '@fxmanager/ui/components/scroll-area';
 import { Checkbox } from '@fxmanager/ui/components/checkbox';
-import { formatDate } from '@/lib/utils';
 import { useEffect, useState } from 'react';
 import type { AuditLog } from '@fxmanager/database/types';
 import { QueryService } from '@/lib/query';
-import { Link } from 'react-router-dom';
 import { Label } from '@fxmanager/ui/components/label';
 import { Input } from '@fxmanager/ui/components/input';
 import type { BaseAdminUser, PaginatedResponse } from '@fxmanager/shared/types';
@@ -46,148 +35,9 @@ import { Calendar } from '@fxmanager/ui/components/calendar';
 import { format } from 'date-fns';
 import type { DateRange } from 'react-day-picker';
 import { toast } from 'sonner';
-
-const ACTION_ICON_MAP: Record<
-	string,
-	React.ComponentType<{ className?: string }>
-> = {
-	server: Server,
-	player: User,
-	whitelist: ScanEye,
-	admin: Shield,
-	report: MessagesSquare,
-	settings: Cog,
-};
+import { AuditLogRow } from './components/auditlog-row';
 
 type AdminItem = { id: number; username: string };
-
-function AuditLogRow({ log }: { log: AuditLog }) {
-	const [isExpanded, setIsExpanded] = useState(false);
-
-	const group = log.action.split('.')[0] || '';
-	const ActionIcon = ACTION_ICON_MAP[group] || FileQuestion;
-
-	const hasObjectData = log.metadata
-		? Object.values(log.metadata).some(
-				(val) => typeof val === 'object' && val !== null,
-			)
-		: false;
-
-	return (
-		<div className="grid grid-cols-[24px_1fr_180px_130px] items-start gap-4 py-3.5 px-2 hover:bg-muted/30 transition-colors border-b last:border-0">
-			<ActionIcon className="h-4 w-4 text-muted-foreground/70 mt-1" />
-
-			<div className="space-y-1.5 min-w-0">
-				<div className="flex flex-wrap items-center gap-2">
-					<span className="text-xs font-semibold uppercase tracking-wider text-foreground">
-						{log.action.replace('_', ' ').replace('.', ': ')}
-					</span>
-
-					{log.player && (
-						<span className="text-xs font-mono bg-muted border border-border/80 text-muted-foreground px-2 py-0.5 rounded">
-							target: {log.player} (#{log.playerId})
-						</span>
-					)}
-				</div>
-
-				{log.metadata && Object.keys(log.metadata).length > 0 && (
-					<div className="text-xs">
-						{hasObjectData ? (
-							<div className="space-y-2 mt-1">
-								<Button
-									type="button"
-									variant="outline"
-									onClick={() => setIsExpanded(!isExpanded)}
-									className="h-6 gap-1.5 px-2 text-[11px] font-semibold cursor-pointer"
-								>
-									<span>{isExpanded ? 'Hide Metadata' : 'View Metadata'}</span>
-									{isExpanded ? (
-										<ChevronUp className="h-3 w-3 opacity-70" />
-									) : (
-										<ChevronDown className="h-3 w-3 opacity-70" />
-									)}
-								</Button>
-
-								{isExpanded && (
-									<div className="col-span-full flex flex-row w-full gap-4 bg-muted/30 border border-border/50 rounded-lg p-3 mt-1">
-										{Object.entries(log.metadata).map(([key, val]) => (
-											<div
-												key={key}
-												className="flex flex-col flex-1 gap-0.5 border-r border-border/40 last:border-0 pr-4 last:pr-0 pb-0"
-											>
-												<span className="font-semibold text-foreground/70 text-[11px] uppercase tracking-wider">
-													{key}
-												</span>
-												<span className="font-mono text-muted-foreground text-xs">
-													{typeof val === 'object' && val !== null ? (
-														<ul className="space-y-1 list-disc pl-4 mt-1">
-															{Object.entries(val).map(
-																([nestedKey, nestedVal]) => (
-																	<li
-																		key={nestedKey}
-																		className="text-muted-foreground/40"
-																	>
-																		<div className="inline-flex items-start gap-1 text-muted-foreground">
-																			<span className="text-muted-foreground/70 font-semibold shrink-0">
-																				{nestedKey}:
-																			</span>
-																			<span className="text-foreground">
-																				{typeof nestedVal === 'object' &&
-																				nestedVal !== null
-																					? JSON.stringify(nestedVal)
-																					: String(nestedVal)}
-																			</span>
-																		</div>
-																	</li>
-																),
-															)}
-														</ul>
-													) : (
-														String(val)
-													)}
-												</span>
-											</div>
-										))}
-									</div>
-								)}
-							</div>
-						) : (
-							<div className="flex flex-wrap gap-x-3 gap-y-1 text-muted-foreground/80 font-medium">
-								{Object.entries(log.metadata).map(([key, val]) => (
-									<span key={key} className="inline-block">
-										<span className="text-muted-foreground/50">{key}:</span>{' '}
-										{String(val)}
-									</span>
-								))}
-							</div>
-						)}
-					</div>
-				)}
-			</div>
-
-			<div className="text-sm mt-0.5">
-				{log.adminId ? (
-					<Link
-						to={`/settings/admins/${log.adminId}`}
-						className="inline-flex items-center text-xs font-medium text-primary-foreground hover:underline bg-primary/40 px-2.5 py-1 rounded-md border"
-					>
-						{log.admin ?? `Admin #${log.adminId}`}
-					</Link>
-				) : (
-					<span className="text-xs font-medium text-muted-foreground bg-muted/60 px-2.5 py-1 rounded-md border border-border">
-						System
-					</span>
-				)}
-			</div>
-
-			<div className="text-right mt-1">
-				<span className="text-xs text-muted-foreground font-medium whitespace-nowrap">
-					{formatDate(log.createdAt)}
-				</span>
-			</div>
-		</div>
-	);
-}
 
 export default function AuditLogPage() {
 	const [auditLogs, setAuditLogs] = useState<AuditLog[]>([]);
@@ -533,9 +383,8 @@ export default function AuditLogPage() {
 					</div>
 				) : auditLogs.length > 0 ? (
 					<div className="divide-y divide-border">
-						{/* Fix: Cleaned up the nested mapping issue completely */}
 						{auditLogs.map((log) => (
-							<AuditLogRow key={log.id} log={log} />
+							<AuditLogRow key={log.id} log={log} showAdmin />
 						))}
 					</div>
 				) : (

--- a/apps/webpanel/src/pages/settings/components/auditlog-row.tsx
+++ b/apps/webpanel/src/pages/settings/components/auditlog-row.tsx
@@ -1,0 +1,172 @@
+import { formatDate } from '@/lib/utils';
+import type { AuditLog } from '@fxmanager/database/types';
+import { Button } from '@fxmanager/ui/components/button';
+import {
+	ChevronDown,
+	ChevronUp,
+	Cog,
+	FileQuestion,
+	MessagesSquare,
+	ScanEye,
+	Server,
+	Shield,
+	Upload,
+	User,
+} from 'lucide-react';
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+const ACTION_ICON_MAP: Record<
+	string,
+	React.ComponentType<{ className?: string }>
+> = {
+	server: Server,
+	player: User,
+	whitelist: ScanEye,
+	admin: Shield,
+	report: MessagesSquare,
+	settings: Cog,
+	migrate: Upload,
+};
+
+export function AuditLogRow({
+	log,
+	showAdmin,
+}: {
+	log: AuditLog;
+	showAdmin?: boolean;
+}) {
+	const [isExpanded, setIsExpanded] = useState(false);
+
+	const group = log.action.split('.')[0] || '';
+	const ActionIcon = ACTION_ICON_MAP[group] || FileQuestion;
+
+	const hasObjectData = log.metadata
+		? Object.values(log.metadata).some(
+				(val) => typeof val === 'object' && val !== null,
+			)
+		: false;
+
+	const gridLayoutClass = showAdmin
+		? 'grid-cols-[24px_1fr_180px_130px]'
+		: 'grid-cols-[24px_1fr_130px]';
+
+	return (
+		<div
+			className={`grid ${gridLayoutClass} items-start gap-4 py-3.5 px-2 hover:bg-muted/30 transition-colors border-b last:border-0`}
+		>
+			<ActionIcon className="h-4 w-4 text-muted-foreground/70 mt-1" />
+
+			<div className="space-y-1.5 min-w-0">
+				<div className="flex flex-wrap items-center gap-2">
+					<span className="text-xs font-semibold uppercase tracking-wider text-foreground">
+						{log.action.replace('_', ' ').replace('.', ': ')}
+					</span>
+
+					{log.player && (
+						<span className="text-xs font-mono bg-muted border border-border/80 text-muted-foreground px-2 py-0.5 rounded">
+							target: {log.player} (#{log.playerId})
+						</span>
+					)}
+				</div>
+
+				{log.metadata && Object.keys(log.metadata).length > 0 && (
+					<div className="text-xs">
+						{hasObjectData ? (
+							<div className="space-y-2 mt-1">
+								<Button
+									type="button"
+									variant="outline"
+									onClick={() => setIsExpanded(!isExpanded)}
+									className="h-6 gap-1.5 px-2 text-[11px] font-semibold cursor-pointer"
+								>
+									<span>{isExpanded ? 'Hide Metadata' : 'View Metadata'}</span>
+									{isExpanded ? (
+										<ChevronUp className="h-3 w-3 opacity-70" />
+									) : (
+										<ChevronDown className="h-3 w-3 opacity-70" />
+									)}
+								</Button>
+
+								{isExpanded && (
+									<div className="col-span-full flex flex-row w-full gap-4 bg-muted/30 border border-border/50 rounded-lg p-3 mt-1">
+										{Object.entries(log.metadata).map(([key, val]) => (
+											<div
+												key={key}
+												className="flex flex-col flex-1 gap-0.5 border-r border-border/40 last:border-0 pr-4 last:pr-0 pb-0"
+											>
+												<span className="font-semibold text-foreground/70 text-[11px] uppercase tracking-wider">
+													{key}
+												</span>
+												<span className="font-mono text-muted-foreground text-xs">
+													{typeof val === 'object' && val !== null ? (
+														<ul className="space-y-1 list-disc pl-4 mt-1">
+															{Object.entries(val).map(
+																([nestedKey, nestedVal]) => (
+																	<li
+																		key={nestedKey}
+																		className="text-muted-foreground/40"
+																	>
+																		<div className="inline-flex items-start gap-1 text-muted-foreground">
+																			<span className="text-muted-foreground/70 font-semibold shrink-0">
+																				{nestedKey}:
+																			</span>
+																			<span className="text-foreground">
+																				{typeof nestedVal === 'object' &&
+																				nestedVal !== null
+																					? JSON.stringify(nestedVal)
+																					: String(nestedVal)}
+																			</span>
+																		</div>
+																	</li>
+																),
+															)}
+														</ul>
+													) : (
+														String(val)
+													)}
+												</span>
+											</div>
+										))}
+									</div>
+								)}
+							</div>
+						) : (
+							<div className="flex flex-wrap gap-x-3 gap-y-1 text-muted-foreground/80 font-medium">
+								{Object.entries(log.metadata).map(([key, val]) => (
+									<span key={key} className="inline-block">
+										<span className="text-muted-foreground/50">{key}:</span>{' '}
+										{String(val)}
+									</span>
+								))}
+							</div>
+						)}
+					</div>
+				)}
+			</div>
+
+			{showAdmin && (
+				<div className="text-sm mt-0.5">
+					{log.adminId ? (
+						<Link
+							to={`/settings/admins/${log.adminId}`}
+							className="inline-flex items-center text-xs font-medium text-primary-foreground hover:underline bg-primary/40 px-2.5 py-1 rounded-md border"
+						>
+							{log.admin ?? `Admin #${log.adminId}`}
+						</Link>
+					) : (
+						<span className="text-xs font-medium text-muted-foreground bg-muted/60 px-2.5 py-1 rounded-md border border-border">
+							System
+						</span>
+					)}
+				</div>
+			)}
+
+			<div className="text-right mt-1">
+				<span className="text-xs text-muted-foreground font-medium whitespace-nowrap">
+					{formatDate(log.createdAt)}
+				</span>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Description

This PR extends the readability of metadata associated to an audit log entry, it allows us to store objects within a metadata key and displays it as an unordered list for better readability.
If we get further nested objects, it'll show a _stringified_ JSON object to avoid `[Object object]` notation.

Adresses the UI issue raised in review comment of #16 

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [x] Builds & runs on Windows
- [x] Builds & runs on Linux

---

## Previews

<img width="1619" height="920" alt="image" src="https://github.com/user-attachments/assets/65479116-6751-43ff-a690-e1662e3cfdac" />
<img width="1621" height="924" alt="image" src="https://github.com/user-attachments/assets/a4251792-1717-4c3a-b3fa-2ccc2eeb0f5f" />
