### PR TITLE
Feat: performance page

### DIFF
--- a/apps/webpanel/src/pages/dashboard/index.tsx
+++ b/apps/webpanel/src/pages/dashboard/index.tsx
@@ -10,11 +10,8 @@ import {
 	CardHeader,
 	CardTitle,
 } from '@fxmanager/ui/components/card';
-import { PerfDistribution } from './perf-distribution';
 
 /* ToDo:
- * Consider adding wider details on process health
- * Displayed as graphs
  * Display connected staff counter
  */
 
@@ -45,26 +42,20 @@ export default function DashboardPage() {
 				description="Server overview."
 			/>
 
-			<div className="grid gap-4 lg:grid-cols-3">
-				<div className="grid content-start gap-4 sm:grid-cols-2 lg:col-span-1 lg:grid-cols-1">
-					{stats.map(({ label, value, icon: Icon }) => (
-						<Card key={label} className="bg-card/50">
-							<CardHeader className="flex flex-row items-center justify-between pb-2 pt-4">
-								<CardTitle className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-									{label}
-								</CardTitle>
-								<Icon className="h-4 w-4 text-muted-foreground" />
-							</CardHeader>
-							<CardContent className="pb-4">
-								<div className="text-2xl font-bold">{value}</div>
-							</CardContent>
-						</Card>
-					))}
-				</div>
-
-				<div className="lg:col-span-2">
-					<PerfDistribution />
-				</div>
+			<div className="grid content-start gap-4 sm:grid-cols-2 lg:col-span-1 lg:grid-cols-2">
+				{stats.map(({ label, value, icon: Icon }) => (
+					<Card key={label} className="bg-card/50">
+						<CardHeader className="flex flex-row items-center justify-between pb-2 pt-4">
+							<CardTitle className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+								{label}
+							</CardTitle>
+							<Icon className="h-4 w-4 text-muted-foreground" />
+						</CardHeader>
+						<CardContent className="pb-4">
+							<div className="text-2xl font-bold">{value}</div>
+						</CardContent>
+					</Card>
+				))}
 			</div>
 		</div>
 	);

--- a/apps/webpanel/src/pages/index.ts
+++ b/apps/webpanel/src/pages/index.ts
@@ -13,6 +13,7 @@ import AdminCreate from './settings/admincreate';
 import { ResourceList } from './resources';
 import WhitelistIndex from './whitelist';
 import AuditLogPage from './settings/auditlogs';
+import PerformancePage from './performance';
 
 type RouteConfig = {
 	path: string;
@@ -37,6 +38,11 @@ export const routes: RouteConfig[] = [
 		path: '/resources',
 		element: ResourceList,
 		permission: UserPermissions.RESOURCE_LIST,
+	},
+	{
+		path: '/perf',
+		element: PerformancePage,
+		permission: UserPermissions.CONSOLE_ACCESS,
 	},
 
 	// Player Management

--- a/apps/webpanel/src/pages/performance/components/perf-buckets.ts
+++ b/apps/webpanel/src/pages/performance/components/perf-buckets.ts
@@ -1,6 +1,6 @@
 // FXServer tickTime bucket upper-bounds (ms); the final band is the +Inf bucket.
 const BUCKET_MS = [1, 2, 4, 6, 8, 10, 15, 20, 30, 50, 70, 100, 150, 250];
-const BAND_LABELS = [...BUCKET_MS.map(String), '+Inf'];
+export const BAND_LABELS = [...BUCKET_MS.map(String), '+Inf'];
 export const BANDS = BAND_LABELS.length;
 
 /** Pretty label for a band index, e.g. `1ms` or `+Inf`. */

--- a/apps/webpanel/src/pages/performance/components/perf-distribution.tsx
+++ b/apps/webpanel/src/pages/performance/components/perf-distribution.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from 'react';
-import { usePerfSocket } from '@/hooks/ws-channels/use-perf';
 import {
 	PERF_WINDOW_MS,
 	type PerfSnapshot,
@@ -69,8 +68,7 @@ function aggregate(
 	};
 }
 
-export function PerfDistribution() {
-	const { samples } = usePerfSocket();
+export function PerfDistribution({ samples }: { samples: PerfSnapshot[] }) {
 	const [thread, setThread] = useState<PerfThread>('svMain');
 
 	const data = useMemo(() => aggregate(samples, thread), [samples, thread]);
@@ -107,7 +105,12 @@ export function PerfDistribution() {
 			</CardHeader>
 			<CardContent>
 				{!data ? (
-					<div className="flex h-[260px] items-center justify-center text-center text-sm text-muted-foreground">
+					<div
+						style={{
+							height: `calc((${BANDS} * 16px) + ((${BANDS} - 1) * 6px))`,
+						}}
+						className="flex items-center justify-center text-center text-sm text-muted-foreground"
+					>
 						No performance data yet. Metrics appear ~30s after the server
 						starts.
 					</div>

--- a/apps/webpanel/src/pages/performance/components/process-stats.tsx
+++ b/apps/webpanel/src/pages/performance/components/process-stats.tsx
@@ -1,0 +1,77 @@
+import {
+	type PerfSnapshot,
+	PERF_THREADS,
+	type PerfThread,
+} from '@fxmanager/shared/types';
+import { bandLabel } from './perf-buckets';
+
+export function PerfStatsGrid({ samples }: { samples: PerfSnapshot[] }) {
+	const latestSample = samples[samples.length - 1];
+
+	const getDominantBucket = (thread: PerfThread) => {
+		if (!latestSample || !latestSample.threads[thread]) return null;
+
+		const currentThread = latestSample.threads[thread];
+		const totalCount = currentThread.count;
+
+		if (totalCount === 0) return null;
+
+		let maxPct = 0;
+		let dominantLabel = '';
+
+		let previousCount = 0;
+		currentThread.buckets.forEach((cumulativeCount, idx) => {
+			const bucketCount = cumulativeCount - previousCount;
+			const pct = (bucketCount / totalCount) * 100;
+
+			if (pct > maxPct) {
+				maxPct = pct;
+				dominantLabel = bandLabel(idx);
+			}
+			previousCount = cumulativeCount;
+		});
+
+		return { label: dominantLabel, percentage: maxPct };
+	};
+
+	return (
+		<div className="grid gap-4 md:grid-cols-3">
+			{PERF_THREADS.map((thread) => {
+				const dominant = getDominantBucket(thread);
+
+				const threadTitle =
+					thread === 'svMain'
+						? 'svMain Majority'
+						: thread === 'svSync'
+							? 'svSync Majority'
+							: 'svNetwork Majority';
+
+				const threadDesc =
+					thread === 'svMain'
+						? 'Dominant tick window for main thread'
+						: thread === 'svSync'
+							? 'Dominant tick window for sync thread'
+							: 'Dominant tick window for network thread';
+
+				return (
+					<div key={thread} className="rounded-xl border bg-card p-4">
+						<p className="text-sm font-medium text-muted-foreground">
+							{threadTitle}
+						</p>
+						{dominant ? (
+							<div className="flex items-baseline gap-2">
+								<p className="text-2xl font-bold">≤ {dominant.label}</p>
+								<span className="text-sm font-semibold text-emerald-500">
+									({dominant.percentage.toFixed(0)}%)
+								</span>
+							</div>
+						) : (
+							<p className="text-2xl font-bold text-muted-foreground">—</p>
+						)}
+						<span className="text-xs text-muted-foreground">{threadDesc}</span>
+					</div>
+				);
+			})}
+		</div>
+	);
+}

--- a/apps/webpanel/src/pages/performance/index.tsx
+++ b/apps/webpanel/src/pages/performance/index.tsx
@@ -1,0 +1,47 @@
+import { ChartBar, InfoIcon } from 'lucide-react';
+import { PageHeader } from '@/components/page-header';
+import { PerfDistribution } from './components/perf-distribution';
+import { PerfStatsGrid } from './components/process-stats';
+import { usePerfSocket } from '@/hooks/ws-channels/use-perf';
+import {
+	Alert,
+	AlertDescription,
+	AlertTitle,
+} from '@fxmanager/ui/components/alert';
+
+/* ToDo:
+ * Expand performance with the ability to see evolution over time
+ * as well as being able to review data from previous sessions.
+*/
+
+export default function PerformancePage() {
+	const { samples } = usePerfSocket();
+
+	return (
+		<div className="flex min-h-[calc(100vh-5rem)] flex-col gap-6">
+			<PageHeader
+				Icon={ChartBar}
+				title="Performance"
+				description="Monitor fxServer thread distribution and system resource usage."
+			/>
+
+			<Alert>
+				<AlertTitle className="flex items-center gap-2 text-base font-semibold tracking-tight text-amber-600 dark:text-amber-500">
+					<InfoIcon className="size-4 shrink-0" />
+					<span>Under Development</span>
+				</AlertTitle>
+				<AlertDescription className="text-sm leading-relaxed">
+					These metrics represent an initial preview of fxServer telemetry.
+					Additional thread diagnostics and historical tracking are coming soon
+					in a future update.
+				</AlertDescription>
+			</Alert>
+
+			<PerfStatsGrid samples={samples} />
+
+			<div className="flex-1">
+				<PerfDistribution samples={samples} />
+			</div>
+		</div>
+	);
+}

--- a/apps/webpanel/src/static/navigation.ts
+++ b/apps/webpanel/src/static/navigation.ts
@@ -8,6 +8,7 @@ import {
 	ShieldUser,
 	BookUser,
 	ScrollText,
+	ChartBar,
 } from 'lucide-react';
 import type { NavCategory } from '@/types/sidebar';
 import { UserPermissions } from '@fxmanager/shared/constants';
@@ -35,6 +36,12 @@ const NAV_SERVER: NavCategory = {
 			title: 'Resource List',
 			url: '/resources',
 			icon: LayoutList,
+			permission: UserPermissions.CONSOLE_ACCESS,
+		},
+		{
+			title: 'Performance',
+			url: '/perf',
+			icon: ChartBar,
 			permission: UserPermissions.CONSOLE_ACCESS,
 		},
 	],

--- a/packages/shared/src/constants/permissions.ts
+++ b/packages/shared/src/constants/permissions.ts
@@ -148,7 +148,7 @@ export const PERMISSION_GROUPS: AdminGroup[] = [
 	},
 	{
 		label: 'Development',
-		permissions: 30720,
+		permissions: 292864,
 		colour: '#00FF00',
 		icon: 'FileCode',
 	},

--- a/packages/shared/src/constants/permissions.ts
+++ b/packages/shared/src/constants/permissions.ts
@@ -28,6 +28,7 @@ export const UserPermissions = {
 	RESOURCE_LIST: 1 << 16, // 65536 - view & (re)start/stop resources
 
 	AUDIT_LOG: 1 << 17, // 131072 - view audit logs
+	PERFORMANCE: 1 << 18, // 262144 - view perfomance data
 
 	MASTER: 1 << 30, // 1073741824
 } as const;
@@ -113,6 +114,11 @@ export const PERMISSION_LABELS: Record<
 	[UserPermissions.AUDIT_LOG]: {
 		label: 'Audit log',
 		desc: 'View the history of all staff actions and system events.',
+		category: 'Administration',
+	},
+	[UserPermissions.PERFORMANCE]: {
+		label: 'Perfomance',
+		desc: 'View server performance data.',
 		category: 'Administration',
 	},
 	[UserPermissions.RESOURCE_LIST]: {


### PR DESCRIPTION
## Description

This PR moves the performance distribution chart from the dashboard to a separate page as it's out of scope.
This is an initial change prior to future enhancements of the performance system with expansions to allow for better analysis of the servers health.

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [x] Builds & runs on Windows
- [x] Builds & ~~runs~~ on Linux

---

## Additional Notes

Preview:
<img width="1615" height="781" alt="image" src="https://github.com/user-attachments/assets/3e58e453-c1df-4863-8143-6e1f7b05d48c" />

