### PR TITLE
fix(core): gracefully stop FXServer child on shutdown signals

### DIFF
--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -30,7 +30,7 @@ checkVersion('dev-build');
 
 const cm = ConfigManager.getInstance();
 const { cookieSecret, webServerPort } = cm.getSystemValues();
-const fastify = Fastify({ logger: !isProduction });
+const fastify = Fastify({ logger: !isProduction, forceCloseConnections: true });
 
 fastify.register(fastifyCookie, {
 	secret: cookieSecret,

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -165,4 +165,23 @@ const start = async () => {
 	}
 };
 
+// Stop the supervised FXServer before exiting so `docker stop` / Ctrl+C shut the child down cleanly instead of orphaning it
+let shuttingDown = false;
+const shutdown = async (signal: string) => {
+	if (shuttingDown) return;
+	shuttingDown = true;
+	console.log(`[core] Received ${signal}, shutting down`);
+	try {
+		await pm.stop();
+		await fastify.close();
+	} catch (err) {
+		console.error('[core] Error during shutdown', err);
+	} finally {
+		process.exit(0);
+	}
+};
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));
+
 start();


### PR DESCRIPTION
## Description
Previously the core only spawned and managed the FXServer child but never handled its own termination. On `SIGTERM` (`docker stop`, systemd, etc) or `SIGINT` (Ctrl+C), the panel process was killed immediately and the spawned FXServer was left to be torn down abruptly rather than stopped cleanly.

This adds `SIGTERM`/`SIGINT` handlers in `apps/core/src/index.ts` that:
- call `ProcessManager.stop()` to stop the running FXServer child,
- close the Fastify server,
- then `process.exit(0)`,
- with a `shuttingDown` guard so a repeated/duplicate signal is a no-op.

`ProcessManager.onExit` already treats exit code `143` as a clean stop, so no spurious "crashed" state is reported.

---

## Tests

- [ ] Tested in development mode
- [x] Passes typecheck
- [ ] Builds & runs on Windows
- [x] Builds & runs on Linux

---

## Additional Notes
Verified by building the Linux target and running the production binary in a container, with the server in the `running` state:

- **SIGTERM** (`docker stop`): child stopped gracefully (`pm.stop()` ran), panel exited with **code 0** in rougly 2-3 seconds.
- **SIGINT** (`docker kill -s SIGINT`): same clean shutdown, **exit code 0**.
- **Restart**: server starts again correctly after the process comes back up.
