### PR TITLE
refactor(core): get fxServer endpoint dynamically

### DIFF
--- a/apps/core/src/common/fxserver-endpoint.test.ts
+++ b/apps/core/src/common/fxserver-endpoint.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'bun:test';
+import {
+	DEFAULT_NET_ENDPOINT,
+	getServerNetEndpoint,
+	parseEndpointCommands,
+	pickConnectEndpoint,
+	resolveCfgEndpoint,
+} from './fxserver-endpoint';
+
+describe('parseEndpointCommands', () => {
+	it('collects tcp and udp entries for the same ip:port', () => {
+		const cfg = `
+			endpoint_add_tcp "0.0.0.0:30120"
+			endpoint_add_udp "0.0.0.0:30120"
+		`;
+		const { endpoints } = parseEndpointCommands(cfg);
+		expect(endpoints['0.0.0.0:30120']).toEqual({ tcp: true, udp: true });
+	});
+
+	it('extracts exec include paths', () => {
+		const cfg = `
+			exec endpoints.cfg
+			exec "cfg/perms.cfg"
+		`;
+		const { execs } = parseEndpointCommands(cfg);
+		expect(execs).toEqual(['endpoints.cfg', 'cfg/perms.cfg']);
+	});
+
+	it('ignores commented-out lines', () => {
+		const cfg = `
+			# endpoint_add_tcp "1.2.3.4:30120"
+			endpoint_add_tcp "0.0.0.0:30120"
+		`;
+		const { endpoints } = parseEndpointCommands(cfg);
+		expect(endpoints['1.2.3.4:30120']).toBeUndefined();
+		expect(endpoints['0.0.0.0:30120']).toEqual({ tcp: true });
+	});
+});
+
+describe('pickConnectEndpoint', () => {
+	it('picks the endpoint present in both tcp and udp', () => {
+		const endpoint = pickConnectEndpoint({
+			'0.0.0.0:30120': { tcp: true, udp: true },
+			'0.0.0.0:40120': { tcp: true },
+		});
+		expect(endpoint).toBe('127.0.0.1:30120');
+	});
+
+	it('normalizes the 0.0.0.0 wildcard bind address to 127.0.0.1', () => {
+		const endpoint = pickConnectEndpoint({
+			'0.0.0.0:30120': { tcp: true, udp: true },
+		});
+		expect(endpoint).toBe('127.0.0.1:30120');
+	});
+
+	it('normalizes the [::] ipv6 wildcard to 127.0.0.1', () => {
+		const endpoint = pickConnectEndpoint({
+			'[::]:30120': { tcp: true, udp: true },
+		});
+		expect(endpoint).toBe('127.0.0.1:30120');
+	});
+
+	it('keeps an explicit bind address untouched', () => {
+		const endpoint = pickConnectEndpoint({
+			'192.168.1.5:30120': { tcp: true, udp: true },
+		});
+		expect(endpoint).toBe('192.168.1.5:30120');
+	});
+
+	it('returns null when no endpoint is in both tcp and udp', () => {
+		const endpoint = pickConnectEndpoint({
+			'0.0.0.0:30120': { tcp: true },
+		});
+		expect(endpoint).toBeNull();
+	});
+});
+
+describe('resolveCfgEndpoint', () => {
+	const reader = (files: Record<string, string>) => async (p: string) => {
+		const norm = p.replace(/\\/g, '/');
+		const content = files[norm];
+		if (content !== undefined) return content;
+		throw new Error(`ENOENT: ${norm}`);
+	};
+
+	it('resolves the endpoint from a single cfg file', async () => {
+		const endpoint = await resolveCfgEndpoint('/srv/server.cfg', {
+			dataDir: '/srv',
+			readFile: reader({
+				'/srv/server.cfg': `
+					endpoint_add_tcp "0.0.0.0:30120"
+					endpoint_add_udp "0.0.0.0:30120"
+				`,
+			}),
+		});
+		expect(endpoint).toBe('127.0.0.1:30120');
+	});
+
+	it('follows exec includes to find the endpoint', async () => {
+		const endpoint = await resolveCfgEndpoint('/srv/server.cfg', {
+			dataDir: '/srv',
+			readFile: reader({
+				'/srv/server.cfg': 'exec endpoints.cfg',
+				'/srv/endpoints.cfg': `
+					endpoint_add_tcp "0.0.0.0:30120"
+					endpoint_add_udp "0.0.0.0:30120"
+				`,
+			}),
+		});
+		expect(endpoint).toBe('127.0.0.1:30120');
+	});
+
+	it('skips unreadable exec includes but still resolves from the main cfg', async () => {
+		const endpoint = await resolveCfgEndpoint('/srv/server.cfg', {
+			dataDir: '/srv',
+			readFile: reader({
+				'/srv/server.cfg': `
+					exec missing.cfg
+					endpoint_add_tcp "0.0.0.0:30120"
+					endpoint_add_udp "0.0.0.0:30120"
+				`,
+			}),
+		});
+		expect(endpoint).toBe('127.0.0.1:30120');
+	});
+
+	it('does not loop forever on circular exec includes', async () => {
+		const endpoint = await resolveCfgEndpoint('/srv/a.cfg', {
+			dataDir: '/srv',
+			readFile: reader({
+				'/srv/a.cfg': 'exec b.cfg',
+				'/srv/b.cfg': 'exec a.cfg',
+			}),
+		});
+		expect(endpoint).toBeNull();
+	});
+
+	it('returns null when the entry cfg is unreadable', async () => {
+		const endpoint = await resolveCfgEndpoint('/srv/server.cfg', {
+			dataDir: '/srv',
+			readFile: reader({}),
+		});
+		expect(endpoint).toBeNull();
+	});
+});
+
+describe('getServerNetEndpoint', () => {
+	it('returns the resolved endpoint when the cfg is resolvable', async () => {
+		const endpoint = await getServerNetEndpoint({
+			cfgPath: '/srv/server.cfg',
+			dataDir: '/srv',
+			readFile: async () => `
+				endpoint_add_tcp "0.0.0.0:30120"
+				endpoint_add_udp "0.0.0.0:30120"
+			`,
+		});
+		expect(endpoint).toBe('127.0.0.1:30120');
+	});
+
+	it('falls back to the default endpoint when nothing resolves', async () => {
+		const endpoint = await getServerNetEndpoint({
+			cfgPath: '/srv/server.cfg',
+			dataDir: '/srv',
+			readFile: async () => {
+				throw new Error('ENOENT');
+			},
+		});
+		expect(endpoint).toBe(DEFAULT_NET_ENDPOINT);
+		expect(endpoint).toBe('127.0.0.1:30120');
+	});
+});

--- a/apps/core/src/common/fxserver-endpoint.ts
+++ b/apps/core/src/common/fxserver-endpoint.ts
@@ -1,0 +1,125 @@
+// Endpoint resolution adapted from txAdmin's fxsConfigHelper (MIT,
+// (c) 2019-2025 Take-Two Interactive Software, Inc.):
+// https://github.com/citizenfx/txAdmin/blob/master/core/lib/fxserver/fxsConfigHelper.ts
+import { readFile as fsReadFile } from 'node:fs/promises';
+import path from 'node:path';
+import { ConfigManager } from '../modules/config/manager';
+
+export const DEFAULT_NET_ENDPOINT = '127.0.0.1:30120';
+
+export interface EndpointFlags {
+	tcp?: boolean;
+	udp?: boolean;
+}
+
+export type EndpointMap = Record<string, EndpointFlags>;
+
+type ReadFile = (path: string) => Promise<string>;
+
+const TOKEN_RE = /"([^"]*)"|(\S+)/g;
+const WILDCARD_RE = /(0\.0\.0\.0|\[::\])/;
+
+function tokenizeLine(line: string): string[] {
+	const tokens: string[] = [];
+	TOKEN_RE.lastIndex = 0;
+	let match: RegExpExecArray | null = TOKEN_RE.exec(line);
+	while (match !== null) {
+		const token = match[1] ?? match[2];
+		if (token !== undefined) tokens.push(token);
+		match = TOKEN_RE.exec(line);
+	}
+	return tokens;
+}
+
+export function parseEndpointCommands(text: string): {
+	endpoints: EndpointMap;
+	execs: string[];
+} {
+	const endpoints: EndpointMap = {};
+	const execs: string[] = [];
+
+	for (const rawLine of text.split(/\r?\n/)) {
+		const line = rawLine.replace(/#.*$/, '').trim();
+		if (!line) continue;
+
+		const [command, arg] = tokenizeLine(line);
+		if (!command || !arg) continue;
+
+		if (command === 'endpoint_add_tcp' || command === 'endpoint_add_udp') {
+			const entry = endpoints[arg] ?? {};
+			entry[command === 'endpoint_add_tcp' ? 'tcp' : 'udp'] = true;
+			endpoints[arg] = entry;
+		} else if (command === 'exec') {
+			execs.push(arg);
+		}
+	}
+
+	return { endpoints, execs };
+}
+
+export function pickConnectEndpoint(endpoints: EndpointMap): string | null {
+	const both = Object.entries(endpoints).find(
+		([, flags]) => flags.tcp && flags.udp,
+	)?.[0];
+	if (!both) return null;
+	return both.replace(WILDCARD_RE, '127.0.0.1');
+}
+
+export async function resolveCfgEndpoint(
+	entryCfgPath: string,
+	opts: { dataDir?: string; readFile?: ReadFile } = {},
+): Promise<string | null> {
+	const readFile = opts.readFile ?? ((p) => fsReadFile(p, 'utf8'));
+	const merged: EndpointMap = {};
+	const visited = new Set<string>();
+
+	const walk = async (cfgPath: string): Promise<void> => {
+		const resolved = path.resolve(cfgPath);
+		if (visited.has(resolved)) return;
+		visited.add(resolved);
+
+		let text: string;
+		try {
+			text = await readFile(cfgPath);
+		} catch {
+			return;
+		}
+
+		const { endpoints, execs } = parseEndpointCommands(text);
+		for (const [ep, flags] of Object.entries(endpoints)) {
+			const entry = merged[ep] ?? {};
+			if (flags.tcp) entry.tcp = true;
+			if (flags.udp) entry.udp = true;
+			merged[ep] = entry;
+		}
+
+		const baseDir = opts.dataDir ?? path.dirname(cfgPath);
+		for (const exec of execs) {
+			if (exec.startsWith('@')) continue; // @resource/foo.cfg not supported
+			await walk(path.isAbsolute(exec) ? exec : path.join(baseDir, exec));
+		}
+	};
+
+	await walk(entryCfgPath);
+	return pickConnectEndpoint(merged);
+}
+
+export async function getServerNetEndpoint(
+	opts: { cfgPath?: string; dataDir?: string; readFile?: ReadFile } = {},
+): Promise<string> {
+	let { cfgPath, dataDir } = opts;
+
+	if (!cfgPath || !dataDir) {
+		const cfg = ConfigManager.getInstance().getFxServerValues(true);
+		dataDir ??= cfg.serverDataPath;
+		cfgPath ??= path.isAbsolute(cfg.serverConfigFile)
+			? cfg.serverConfigFile
+			: path.join(cfg.serverDataPath, cfg.serverConfigFile);
+	}
+
+	const resolved = await resolveCfgEndpoint(cfgPath, {
+		dataDir,
+		readFile: opts.readFile,
+	});
+	return resolved ?? DEFAULT_NET_ENDPOINT;
+}

--- a/apps/core/src/modules/perf/manager.ts
+++ b/apps/core/src/modules/perf/manager.ts
@@ -5,10 +5,7 @@ import {
 } from '@fxmanager/shared/types';
 import { diffPerfs, didPerfReset, parseRawPerf } from './parser';
 import { wsManager } from '../ws/manager';
-
-// TODO: replace this with a utility function for getting the actual server endpoint at a later date
-const PERF_PORT = 30120;
-const PERF_ENDPOINT = `http://localhost:${PERF_PORT}/perf.json`;
+import { getServerNetEndpoint } from '../../common/fxserver-endpoint';
 
 const SAMPLE_INTERVAL_MS = 30_000;
 
@@ -17,7 +14,7 @@ class PerfManager {
 	private lastRaw: RawPerf | null = null;
 	private recent: PerfSnapshot[] = [];
 
-	/** Poll `/perf.json` continuously, regardless of who started the fxserver. */
+	/** Poll `/perf/` continuously, regardless of who started the fxserver. */
 	start(): void {
 		if (this.interval) return;
 		void this.tick();
@@ -40,7 +37,8 @@ class PerfManager {
 
 	private async fetchRawPerfData(): Promise<RawPerf | null> {
 		try {
-			const res = await fetch(PERF_ENDPOINT, {
+			const endpoint = await getServerNetEndpoint();
+			const res = await fetch(`http://${endpoint}/perf/`, {
 				signal: AbortSignal.timeout(SAMPLE_INTERVAL_MS / 2),
 			});
 			if (!res.ok) return null;


### PR DESCRIPTION
## Description

We used to get the fxServer endpoint by hardcoded localhost:30120 which would fail if anyone changed their endpoint(s).

This PR pretty much just replaces the hardcoded endpoint with a standalone resolver that derives the fxServer http endpoint from the server config the same way that txAdmin does.

Its adapted from the txAdmin fxsConfigHelper and I just added their license at the top of the file.

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [x] Builds & runs on Windows
- [x] Builds & runs on Linux

