### PR TITLE
fix(core): stalls & http errors counts as crashes

### DIFF
--- a/apps/core/src/common/fxserver-endpoint.test.ts
+++ b/apps/core/src/common/fxserver-endpoint.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'bun:test';
+import {
+	DEFAULT_NET_ENDPOINT,
+	getServerNetEndpoint,
+	parseEndpointCommands,
+	pickConnectEndpoint,
+	resolveCfgEndpoint,
+} from './fxserver-endpoint';
+
+describe('parseEndpointCommands', () => {
+	it('collects tcp and udp entries for the same ip:port', () => {
+		const cfg = `
+			endpoint_add_tcp "0.0.0.0:30120"
+			endpoint_add_udp "0.0.0.0:30120"
+		`;
+		const { endpoints } = parseEndpointCommands(cfg);
+		expect(endpoints['0.0.0.0:30120']).toEqual({ tcp: true, udp: true });
+	});
+
+	it('extracts exec include paths', () => {
+		const cfg = `
+			exec endpoints.cfg
+			exec "cfg/perms.cfg"
+		`;
+		const { execs } = parseEndpointCommands(cfg);
+		expect(execs).toEqual(['endpoints.cfg', 'cfg/perms.cfg']);
+	});
+
+	it('ignores commented-out lines', () => {
+		const cfg = `
+			# endpoint_add_tcp "1.2.3.4:30120"
+			endpoint_add_tcp "0.0.0.0:30120"
+		`;
+		const { endpoints } = parseEndpointCommands(cfg);
+		expect(endpoints['1.2.3.4:30120']).toBeUndefined();
+		expect(endpoints['0.0.0.0:30120']).toEqual({ tcp: true });
+	});
+});
+
+describe('pickConnectEndpoint', () => {
+	it('picks the endpoint present in both tcp and udp', () => {
+		const endpoint = pickConnectEndpoint({
+			'0.0.0.0:30120': { tcp: true, udp: true },
+			'0.0.0.0:40120': { tcp: true },
+		});
+		expect(endpoint).toBe('127.0.0.1:30120');
+	});
+
+	it('normalizes the 0.0.0.0 wildcard bind address to 127.0.0.1', () => {
+		const endpoint = pickConnectEndpoint({
+			'0.0.0.0:30120': { tcp: true, udp: true },
+		});
+		expect(endpoint).toBe('127.0.0.1:30120');
+	});
+
+	it('normalizes the [::] ipv6 wildcard to 127.0.0.1', () => {
+		const endpoint = pickConnectEndpoint({
+			'[::]:30120': { tcp: true, udp: true },
+		});
+		expect(endpoint).toBe('127.0.0.1:30120');
+	});
+
+	it('keeps an explicit bind address untouched', () => {
+		const endpoint = pickConnectEndpoint({
+			'192.168.1.5:30120': { tcp: true, udp: true },
+		});
+		expect(endpoint).toBe('192.168.1.5:30120');
+	});
+
+	it('returns null when no endpoint is in both tcp and udp', () => {
+		const endpoint = pickConnectEndpoint({
+			'0.0.0.0:30120': { tcp: true },
+		});
+		expect(endpoint).toBeNull();
+	});
+});
+
+describe('resolveCfgEndpoint', () => {
+	const reader = (files: Record<string, string>) => async (p: string) => {
+		const norm = p.replace(/\\/g, '/');
+		const content = files[norm];
+		if (content !== undefined) return content;
+		throw new Error(`ENOENT: ${norm}`);
+	};
+
+	it('resolves the endpoint from a single cfg file', async () => {
+		const endpoint = await resolveCfgEndpoint('/srv/server.cfg', {
+			dataDir: '/srv',
+			readFile: reader({
+				'/srv/server.cfg': `
+					endpoint_add_tcp "0.0.0.0:30120"
+					endpoint_add_udp "0.0.0.0:30120"
+				`,
+			}),
+		});
+		expect(endpoint).toBe('127.0.0.1:30120');
+	});
+
+	it('follows exec includes to find the endpoint', async () => {
+		const endpoint = await resolveCfgEndpoint('/srv/server.cfg', {
+			dataDir: '/srv',
+			readFile: reader({
+				'/srv/server.cfg': 'exec endpoints.cfg',
+				'/srv/endpoints.cfg': `
+					endpoint_add_tcp "0.0.0.0:30120"
+					endpoint_add_udp "0.0.0.0:30120"
+				`,
+			}),
+		});
+		expect(endpoint).toBe('127.0.0.1:30120');
+	});
+
+	it('skips unreadable exec includes but still resolves from the main cfg', async () => {
+		const endpoint = await resolveCfgEndpoint('/srv/server.cfg', {
+			dataDir: '/srv',
+			readFile: reader({
+				'/srv/server.cfg': `
+					exec missing.cfg
+					endpoint_add_tcp "0.0.0.0:30120"
+					endpoint_add_udp "0.0.0.0:30120"
+				`,
+			}),
+		});
+		expect(endpoint).toBe('127.0.0.1:30120');
+	});
+
+	it('does not loop forever on circular exec includes', async () => {
+		const endpoint = await resolveCfgEndpoint('/srv/a.cfg', {
+			dataDir: '/srv',
+			readFile: reader({
+				'/srv/a.cfg': 'exec b.cfg',
+				'/srv/b.cfg': 'exec a.cfg',
+			}),
+		});
+		expect(endpoint).toBeNull();
+	});
+
+	it('returns null when the entry cfg is unreadable', async () => {
+		const endpoint = await resolveCfgEndpoint('/srv/server.cfg', {
+			dataDir: '/srv',
+			readFile: reader({}),
+		});
+		expect(endpoint).toBeNull();
+	});
+});
+
+describe('getServerNetEndpoint', () => {
+	it('returns the resolved endpoint when the cfg is resolvable', async () => {
+		const endpoint = await getServerNetEndpoint({
+			cfgPath: '/srv/server.cfg',
+			dataDir: '/srv',
+			readFile: async () => `
+				endpoint_add_tcp "0.0.0.0:30120"
+				endpoint_add_udp "0.0.0.0:30120"
+			`,
+		});
+		expect(endpoint).toBe('127.0.0.1:30120');
+	});
+
+	it('falls back to the default endpoint when nothing resolves', async () => {
+		const endpoint = await getServerNetEndpoint({
+			cfgPath: '/srv/server.cfg',
+			dataDir: '/srv',
+			readFile: async () => {
+				throw new Error('ENOENT');
+			},
+		});
+		expect(endpoint).toBe(DEFAULT_NET_ENDPOINT);
+		expect(endpoint).toBe('127.0.0.1:30120');
+	});
+});

--- a/apps/core/src/common/fxserver-endpoint.ts
+++ b/apps/core/src/common/fxserver-endpoint.ts
@@ -1,0 +1,125 @@
+// Endpoint resolution adapted from txAdmin's fxsConfigHelper (MIT,
+// (c) 2019-2025 Take-Two Interactive Software, Inc.):
+// https://github.com/citizenfx/txAdmin/blob/master/core/lib/fxserver/fxsConfigHelper.ts
+import { readFile as fsReadFile } from 'node:fs/promises';
+import path from 'node:path';
+import { ConfigManager } from '../modules/config/manager';
+
+export const DEFAULT_NET_ENDPOINT = '127.0.0.1:30120';
+
+export interface EndpointFlags {
+	tcp?: boolean;
+	udp?: boolean;
+}
+
+export type EndpointMap = Record<string, EndpointFlags>;
+
+type ReadFile = (path: string) => Promise<string>;
+
+const TOKEN_RE = /"([^"]*)"|(\S+)/g;
+const WILDCARD_RE = /(0\.0\.0\.0|\[::\])/;
+
+function tokenizeLine(line: string): string[] {
+	const tokens: string[] = [];
+	TOKEN_RE.lastIndex = 0;
+	let match: RegExpExecArray | null = TOKEN_RE.exec(line);
+	while (match !== null) {
+		const token = match[1] ?? match[2];
+		if (token !== undefined) tokens.push(token);
+		match = TOKEN_RE.exec(line);
+	}
+	return tokens;
+}
+
+export function parseEndpointCommands(text: string): {
+	endpoints: EndpointMap;
+	execs: string[];
+} {
+	const endpoints: EndpointMap = {};
+	const execs: string[] = [];
+
+	for (const rawLine of text.split(/\r?\n/)) {
+		const line = rawLine.replace(/#.*$/, '').trim();
+		if (!line) continue;
+
+		const [command, arg] = tokenizeLine(line);
+		if (!command || !arg) continue;
+
+		if (command === 'endpoint_add_tcp' || command === 'endpoint_add_udp') {
+			const entry = endpoints[arg] ?? {};
+			entry[command === 'endpoint_add_tcp' ? 'tcp' : 'udp'] = true;
+			endpoints[arg] = entry;
+		} else if (command === 'exec') {
+			execs.push(arg);
+		}
+	}
+
+	return { endpoints, execs };
+}
+
+export function pickConnectEndpoint(endpoints: EndpointMap): string | null {
+	const both = Object.entries(endpoints).find(
+		([, flags]) => flags.tcp && flags.udp,
+	)?.[0];
+	if (!both) return null;
+	return both.replace(WILDCARD_RE, '127.0.0.1');
+}
+
+export async function resolveCfgEndpoint(
+	entryCfgPath: string,
+	opts: { dataDir?: string; readFile?: ReadFile } = {},
+): Promise<string | null> {
+	const readFile = opts.readFile ?? ((p) => fsReadFile(p, 'utf8'));
+	const merged: EndpointMap = {};
+	const visited = new Set<string>();
+
+	const walk = async (cfgPath: string): Promise<void> => {
+		const resolved = path.resolve(cfgPath);
+		if (visited.has(resolved)) return;
+		visited.add(resolved);
+
+		let text: string;
+		try {
+			text = await readFile(cfgPath);
+		} catch {
+			return;
+		}
+
+		const { endpoints, execs } = parseEndpointCommands(text);
+		for (const [ep, flags] of Object.entries(endpoints)) {
+			const entry = merged[ep] ?? {};
+			if (flags.tcp) entry.tcp = true;
+			if (flags.udp) entry.udp = true;
+			merged[ep] = entry;
+		}
+
+		const baseDir = opts.dataDir ?? path.dirname(cfgPath);
+		for (const exec of execs) {
+			if (exec.startsWith('@')) continue; // @resource/foo.cfg not supported
+			await walk(path.isAbsolute(exec) ? exec : path.join(baseDir, exec));
+		}
+	};
+
+	await walk(entryCfgPath);
+	return pickConnectEndpoint(merged);
+}
+
+export async function getServerNetEndpoint(
+	opts: { cfgPath?: string; dataDir?: string; readFile?: ReadFile } = {},
+): Promise<string> {
+	let { cfgPath, dataDir } = opts;
+
+	if (!cfgPath || !dataDir) {
+		const cfg = ConfigManager.getInstance().getFxServerValues(true);
+		dataDir ??= cfg.serverDataPath;
+		cfgPath ??= path.isAbsolute(cfg.serverConfigFile)
+			? cfg.serverConfigFile
+			: path.join(cfg.serverDataPath, cfg.serverConfigFile);
+	}
+
+	const resolved = await resolveCfgEndpoint(cfgPath, {
+		dataDir,
+		readFile: opts.readFile,
+	});
+	return resolved ?? DEFAULT_NET_ENDPOINT;
+}

--- a/apps/core/src/modules/perf/manager.ts
+++ b/apps/core/src/modules/perf/manager.ts
@@ -5,10 +5,7 @@ import {
 } from '@fxmanager/shared/types';
 import { diffPerfs, didPerfReset, parseRawPerf } from './parser';
 import { wsManager } from '../ws/manager';
-
-// TODO: replace this with a utility function for getting the actual server endpoint at a later date
-const PERF_PORT = 30120;
-const PERF_ENDPOINT = `http://localhost:${PERF_PORT}/perf.json`;
+import { getServerNetEndpoint } from '../../common/fxserver-endpoint';
 
 const SAMPLE_INTERVAL_MS = 30_000;
 
@@ -17,7 +14,7 @@ class PerfManager {
 	private lastRaw: RawPerf | null = null;
 	private recent: PerfSnapshot[] = [];
 
-	/** Poll `/perf.json` continuously, regardless of who started the fxserver. */
+	/** Poll `/perf/` continuously, regardless of who started the fxserver. */
 	start(): void {
 		if (this.interval) return;
 		void this.tick();
@@ -40,7 +37,8 @@ class PerfManager {
 
 	private async fetchRawPerfData(): Promise<RawPerf | null> {
 		try {
-			const res = await fetch(PERF_ENDPOINT, {
+			const endpoint = await getServerNetEndpoint();
+			const res = await fetch(`http://${endpoint}/perf/`, {
 				signal: AbortSignal.timeout(SAMPLE_INTERVAL_MS / 2),
 			});
 			if (!res.ok) return null;

--- a/apps/core/src/modules/process/manager.test.ts
+++ b/apps/core/src/modules/process/manager.test.ts
@@ -279,6 +279,108 @@ describe('ProcessManager', () => {
 		});
 	});
 
+	describe('Recovery from failed / hung starts', () => {
+		it('marks the server crashed and clears the process when it exits during startup without authenticating', async () => {
+			await processManager.start();
+			expect(processManager.getState().status).toBe('starting');
+
+			pushToStream(
+				stderrController,
+				'An error occurred while checking server license key: HTTP 429: Too Many Requests\n',
+			);
+			if (currentTriggerExit) currentTriggerExit(1);
+			await Bun.sleep(15);
+
+			expect(processManager.getState().status).toBe('crashed');
+			expect((processManager as any).proc).toBeNull();
+		});
+
+		it('lets the operator stop a server that is stuck in starting', async () => {
+			await processManager.start();
+			expect(processManager.getState().status).toBe('starting');
+
+			const result = await processManager.stop();
+
+			expect(result).toBe(true);
+			expect(processManager.getState().status).toBe('stopped');
+			expect((processManager as any).proc).toBeNull();
+		});
+
+		it('kills a start that goes silent and marks it crashed once the stall window elapses', async () => {
+			const watched = new ProcessManagerModule.ProcessManager({
+				startupStallMs: 40,
+			});
+			(watched as any).buffer = {
+				push: mockBufferPush,
+				getHistory: mockGetHistory,
+			};
+
+			await watched.start();
+			expect(watched.getState().status).toBe('starting');
+
+			await Bun.sleep(120);
+
+			expect(watched.getState().status).toBe('crashed');
+			expect((watched as any).proc).toBeNull();
+		});
+
+		it('does not kill a slow start that keeps logging progress past the stall window', async () => {
+			const watched = new ProcessManagerModule.ProcessManager({
+				startupStallMs: 60,
+			});
+			(watched as any).buffer = {
+				push: mockBufferPush,
+				getHistory: mockGetHistory,
+			};
+
+			await watched.start();
+
+			// keep emitting boot output with gaps shorter than the stall window,
+			// for a total span well beyond it
+			for (let i = 0; i < 6; i++) {
+				pushToStream(stdoutController, `Started resource sample-${i}\n`);
+				await Bun.sleep(30);
+			}
+
+			expect(watched.getState().status).toBe('starting');
+			expect((watched as any).proc).not.toBeNull();
+		});
+
+		it('refuses to start again while already starting, avoiding an orphaned child process', async () => {
+			await processManager.start();
+			const spawnCallsAfterFirst = (Bun.spawn as any).mock.calls.length;
+
+			const result = await processManager.start();
+
+			expect(result).toBe(false);
+			expect((Bun.spawn as any).mock.calls.length).toBe(spawnCallsAfterFirst);
+		});
+
+		it('does not get stuck in starting when spawn throws', async () => {
+			Bun.spawn = mock(() => {
+				throw new Error('Fatal Native Binary Execution Fault');
+			}) as any;
+
+			const result = await processManager.start();
+
+			expect(result).toBe(false);
+			expect(processManager.getState().status).not.toBe('starting');
+			expect((processManager as any).proc).toBeNull();
+		});
+
+		it('recovers a server stuck in starting via restart()', async () => {
+			await processManager.start();
+			expect(processManager.getState().status).toBe('starting');
+
+			const stopSpy = spyOn(processManager, 'stop');
+			await processManager.restart();
+
+			expect(stopSpy).toHaveBeenCalled();
+			expect(processManager.getState().status).toBe('starting');
+			expect((processManager as any).proc).not.toBeNull();
+		});
+	});
+
 	describe('sendCommand()', () => {
 		it('should securely throw validation errors if an external user targets an inactive process standard input pipe', () => {
 			expect(() => processManager.sendCommand('status')).toThrow(

--- a/apps/core/src/modules/process/manager.ts
+++ b/apps/core/src/modules/process/manager.ts
@@ -8,14 +8,30 @@ import { ConfigManager } from '../config/manager';
 import { wsManager } from '../ws/manager';
 import { resourceManager } from '../resource/manager';
 
+const STARTUP_STALL_MS = 90_000;
+const KILL_GRACE_MS = 5_000;
+
 export class ProcessManager {
 	private state: ServerState = { status: 'stopped', startedAt: null };
 	private proc: ReturnType<typeof Bun.spawn> | null = null;
 	private buffer = new LogBuffer<ProcessOutputLine>();
 	private config = ConfigManager.getInstance();
+	private startupTimer: ReturnType<typeof setTimeout> | null = null;
+	private readonly startupStallMs: number;
+
+	constructor(opts?: { startupStallMs?: number }) {
+		this.startupStallMs = opts?.startupStallMs ?? STARTUP_STALL_MS;
+	}
 
 	// region process methods
 	async start() {
+		if (this.state.status !== 'stopped' && this.state.status !== 'crashed') {
+			console.warn(
+				`[core] start() ignored, server is already '${this.state.status}'`,
+			);
+			return false;
+		}
+
 		this.config.regenerateApiToken();
 		const systemValues = this.config.getSystemValues();
 		const fxServerValues = this.config.getFxServerValues(true);
@@ -69,19 +85,31 @@ export class ProcessManager {
 			);
 
 			this.proc.exited.then((code) => this.onExit(code));
+			this.armStartupWatchdog();
 
 			return true;
 		} catch (err) {
 			console.error(`[core] Failed to start fxServer`, err);
+			this.clearStartupWatchdog();
+			this.proc = null;
+			this.setState('crashed');
 			return false;
 		}
 	}
 
 	async stop() {
-		if (this.state.status !== 'running' || !this.proc) return false;
+		if (
+			!this.proc ||
+			this.state.status === 'stopping' ||
+			this.state.status === 'stopped'
+		)
+			return false;
+
+		const proc = this.proc;
 
 		console.log(`[core] Stopping fxServer`);
 		this.setState('stopping');
+		this.clearStartupWatchdog();
 
 		this.injectConsoleLine({
 			payload: {
@@ -95,12 +123,9 @@ export class ProcessManager {
 			} satisfies ProcessOutputLine,
 		});
 
-		this.proc.kill();
-		await this.proc.exited;
-		this.proc = null;
+		await this.terminate(proc);
 
 		console.log(`[core] fxServer has stopped`);
-		this.setState('stopped');
 
 		this.injectConsoleLine({
 			payload: {
@@ -118,7 +143,8 @@ export class ProcessManager {
 	}
 
 	async restart() {
-		if (this.state.status === 'running') await this.stop();
+		if (this.state.status === 'running' || this.state.status === 'starting')
+			await this.stop();
 		await this.start();
 
 		return true;
@@ -214,6 +240,57 @@ export class ProcessManager {
 		}
 	}
 
+	private armStartupWatchdog() {
+		this.clearStartupWatchdog();
+		this.startupTimer = setTimeout(() => {
+			void this.onStartupStalled();
+		}, this.startupStallMs);
+		this.startupTimer.unref?.();
+	}
+
+	private clearStartupWatchdog() {
+		if (this.startupTimer) {
+			clearTimeout(this.startupTimer);
+			this.startupTimer = null;
+		}
+	}
+
+	private async onStartupStalled() {
+		if (this.state.status !== 'starting' || !this.proc) return;
+
+		console.warn(
+			`[core] fxServer produced no output for ${this.startupStallMs}ms while starting, terminating it`,
+		);
+		this.injectConsoleLine({
+			process: 'fxManager',
+			value:
+				'Server stalled while starting (no output — possible license/auth issue). Stopping it so you can try again.',
+			color: '\x1b[38;5;196m',
+		});
+
+		await this.terminate(this.proc);
+	}
+
+	private async terminate(proc: ReturnType<typeof Bun.spawn>) {
+		proc.kill();
+
+		let escalation: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+			try {
+				proc.kill('SIGKILL');
+			} catch {}
+		}, KILL_GRACE_MS);
+		escalation.unref?.();
+
+		try {
+			await proc.exited;
+		} finally {
+			if (escalation) {
+				clearTimeout(escalation);
+				escalation = null;
+			}
+		}
+	}
+
 	private createLineBreakTransformer() {
 		let buffer = '';
 		return new TransformStream<string, string>({
@@ -258,11 +335,13 @@ export class ProcessManager {
 					ts: Date.now(),
 				} satisfies ProcessOutputLine;
 
-				if (
-					this.state.status === 'starting' &&
-					value.includes('Authenticated with cfx.re Nucleus')
-				) {
-					this.setState('running');
+				if (this.state.status === 'starting') {
+					if (value.includes('Authenticated with cfx.re Nucleus')) {
+						this.clearStartupWatchdog();
+						this.setState('running');
+					} else {
+						this.armStartupWatchdog();
+					}
 				}
 
 				console.log(value);
@@ -279,15 +358,26 @@ export class ProcessManager {
 		}
 	}
 
-	/* ToDo: implement onExit checks to clean up */
 	private async onExit(code: number | null) {
-		const crashed =
-			code !== 143 &&
-			code !== 0 &&
-			code !== null &&
-			this.state.status !== 'stopping';
+		this.clearStartupWatchdog();
+		const previous = this.state.status;
+		this.proc = null;
 
-		if (crashed) {
+		if (previous === 'stopping' || previous === 'stopped') {
+			this.setState('stopped');
+			return;
+		}
+
+		if (previous === 'starting') {
+			console.warn(`[core] fxServer exited during startup with code ${code}`);
+			this.setState('crashed');
+			return;
+		}
+
+		const graceful = code === 0 || code === 143 || code === null;
+		if (graceful) {
+			this.setState('stopped');
+		} else {
 			console.warn(`[core] fxServer process exited with code ${code}`);
 			this.setState('crashed');
 		}

--- a/apps/webpanel/src/components/sidebar/server-status.tsx
+++ b/apps/webpanel/src/components/sidebar/server-status.tsx
@@ -68,9 +68,10 @@ export function ServerStatusCard() {
 	const { count } = usePlayerlistSocket();
 	const { state: sideBarState, setOpen } = useSidebar();
 	const isCollapsed = sideBarState === 'collapsed';
-	const isRunning = serverState.status === 'running';
 	const canStart =
 		serverState.status === 'stopped' || serverState.status === 'crashed';
+	const canStop =
+		serverState.status === 'running' || serverState.status === 'starting';
 
 	if (isCollapsed) {
 		return (
@@ -120,14 +121,14 @@ export function ServerStatusCard() {
 							/>
 							<ActionButton
 								action="stop"
-								disabled={!isRunning}
+								disabled={!canStop}
 								colour="destructive"
 								Icon={Square}
 								tooltip="Stop server"
 							/>
 							<ActionButton
 								action="restart"
-								disabled={!isRunning}
+								disabled={!canStop}
 								colour="primary"
 								Icon={RefreshCw}
 								tooltip="Restart server"


### PR DESCRIPTION
## Description
Beforehand if your server stalled or got a http error from adhesive for rate limiting etc. you would be stuck in a deadloop where you could never recover as you couldnt start, stop or restart the server.

This PR pretty much fixes it, with a watchdog function that looks over the current state of the server while its booting up and evaluates weather or not a stall or a crash has occoured and then kills the process so users can manually restart if they wish to.

Not sure if we should have a setting for "auto restart" or something but that seems kinda out of scope for this PR.

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [x] Builds & runs on Windows
- [x] Builds & runs on Linux
