### PR TITLE
feat: txAdmin compatibility layer + scheduled restarts

### DIFF
--- a/apps/core/src/common/fxserver-version.ts
+++ b/apps/core/src/common/fxserver-version.ts
@@ -2,5 +2,5 @@ const FXSERVER_BUILD_REGEX = /v1\.0\.0\.(\d{4,8})/;
 
 export function parseFxServerBuild(version: string): string | null {
 	const match = FXSERVER_BUILD_REGEX.exec(version);
-	return match ? match[1] : null;
+	return match?.[1] ?? null;
 }

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -14,6 +14,7 @@ import { ProcessManager } from './modules/process/manager';
 import { GameManager } from './modules/game/manager';
 import { ConfigManager } from './modules/config/manager';
 import { perfManager } from './modules/perf/manager';
+import { restartScheduler } from './modules/schedule/manager';
 import { applyMigrations } from '@fxmanager/database';
 import { MIGRATE_WORKER_FLAG, runMigrateWorker } from './migrate-worker';
 
@@ -80,6 +81,7 @@ const pm = new ProcessManager();
 const gm = new GameManager();
 
 perfManager.start();
+restartScheduler.start(pm);
 
 fastify.register(apiRoutes, { prefix: '/api', pm, gm });
 fastify.register(internalRoutes, { prefix: '/internal', pm, gm });

--- a/apps/core/src/modules/game/manager.test.ts
+++ b/apps/core/src/modules/game/manager.test.ts
@@ -34,6 +34,10 @@ mock.module('@fxmanager/database', () => ({
 	},
 }));
 
+mock.module('../../common/fxserver-endpoint', () => ({
+	getServerNetEndpoint: async () => '127.0.0.1:30120',
+}));
+
 const GameManagerModule = await import('./manager');
 import type { PlayerIdentifiers } from '@fxmanager/shared/types';
 
@@ -415,7 +419,7 @@ describe('GameManager', () => {
 			const response = await gameManager.dropPlayer(2, 'Exploiting Loop holes');
 
 			expect(global.fetch).toHaveBeenCalledWith(
-				'http://localhost:30120/fxManager/drop',
+				'http://127.0.0.1:30120/fxManager/drop',
 				{
 					method: 'POST',
 					body: JSON.stringify({

--- a/apps/core/src/modules/game/manager.ts
+++ b/apps/core/src/modules/game/manager.ts
@@ -11,6 +11,7 @@ import type {
 import { wsManager } from '../ws/manager';
 import { discordManager } from '../discord/manager';
 import { ConfigManager } from '../config/manager';
+import { getServerNetEndpoint } from '../../common/fxserver-endpoint';
 
 export class GameManager {
 	private playerlist: OnlinePlayer[] = [];
@@ -223,7 +224,8 @@ export class GameManager {
 	async dropPlayer(serverId: number, reason: string): Promise<ApiResponse> {
 		try {
 			const resourceToken = await this.getApiToken();
-			const response = await fetch('http://localhost:30120/fxManager/drop', {
+			const endpoint = await getServerNetEndpoint();
+			const response = await fetch(`http://${endpoint}/fxManager/drop`, {
 				method: 'POST',
 				body: JSON.stringify({
 					serverId,

--- a/apps/core/src/modules/process/manager.test.ts
+++ b/apps/core/src/modules/process/manager.test.ts
@@ -14,6 +14,7 @@ import {
 import { ConfigManager } from '../config/manager';
 import { wsManager } from '../ws/manager';
 import { resourceManager } from '../resource/manager';
+import { txAdminCompat } from '../txadmin/compat';
 
 const mockGetHistory = mock(() => []);
 const mockBufferPush = mock(() => {});
@@ -47,6 +48,7 @@ const stoppingServerSpy = spyOn(
 	resourceManager,
 	'stoppingServer',
 ).mockImplementation(() => {});
+const txEmitSpy = spyOn(txAdminCompat, 'emit').mockResolvedValue(undefined);
 
 const ProcessManagerModule = await import('./manager');
 type ProcessManagerInstance = InstanceType<
@@ -105,6 +107,7 @@ describe('ProcessManager', () => {
 		broadcastSpy.mockClear();
 		loadResourcesSpy.mockClear();
 		stoppingServerSpy.mockClear();
+		txEmitSpy.mockClear();
 
 		stdoutController = null;
 		stderrController = null;
@@ -127,7 +130,9 @@ describe('ProcessManager', () => {
 			),
 		) as any;
 
-		processManager = new ProcessManagerModule.ProcessManager();
+		processManager = new ProcessManagerModule.ProcessManager({
+			shutdownGraceMs: 0,
+		});
 
 		// FORCE BIND SPIES onto the instantiated internal buffer field directly
 		(processManager as any).buffer = {
@@ -147,6 +152,7 @@ describe('ProcessManager', () => {
 		broadcastSpy.mockRestore();
 		loadResourcesSpy.mockRestore();
 		stoppingServerSpy.mockRestore();
+		txEmitSpy.mockRestore();
 	});
 
 	const pushToStream = (
@@ -303,6 +309,63 @@ describe('ProcessManager', () => {
 
 			expect(stopSpy).toHaveBeenCalled();
 			expect(startSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe('txAdmin serverShuttingDown compat', () => {
+		it('relays serverShuttingDown when stopping a running server, with the grace delay and author', async () => {
+			await processManager.start();
+			pushToStream(stdoutController, 'Authenticated with cfx.re Nucleus\n');
+			await Bun.sleep(15);
+			expect(processManager.getState().status).toBe('running');
+
+			const stopPromise = processManager.stop({ author: 'Maximus' });
+			if (currentTriggerExit) currentTriggerExit(0);
+			await stopPromise;
+
+			expect(txEmitSpy).toHaveBeenCalledWith(
+				'serverShuttingDown',
+				expect.objectContaining({ delay: 0, author: 'Maximus' }),
+			);
+		});
+
+		it('defaults the author to System when none is supplied', async () => {
+			await processManager.start();
+			pushToStream(stdoutController, 'Authenticated with cfx.re Nucleus\n');
+			await Bun.sleep(15);
+
+			const stopPromise = processManager.stop();
+			if (currentTriggerExit) currentTriggerExit(0);
+			await stopPromise;
+
+			expect(txEmitSpy).toHaveBeenCalledWith(
+				'serverShuttingDown',
+				expect.objectContaining({ author: 'System' }),
+			);
+		});
+
+		it('does not relay serverShuttingDown when stopping a server still starting', async () => {
+			await processManager.start();
+			expect(processManager.getState().status).toBe('starting');
+
+			await processManager.stop();
+
+			expect(txEmitSpy).not.toHaveBeenCalled();
+		});
+
+		it('relays serverShuttingDown once on the stop leg of a restart', async () => {
+			await processManager.start();
+			pushToStream(stdoutController, 'Authenticated with cfx.re Nucleus\n');
+			await Bun.sleep(15);
+
+			const restartPromise = processManager.restart({ author: 'Maximus' });
+			if (currentTriggerExit) currentTriggerExit(143);
+			await restartPromise;
+
+			const shutdownCalls = txEmitSpy.mock.calls.filter(
+				(call) => call[0] === 'serverShuttingDown',
+			);
+			expect(shutdownCalls).toHaveLength(1);
 		});
 	});
 

--- a/apps/core/src/modules/process/manager.ts
+++ b/apps/core/src/modules/process/manager.ts
@@ -10,9 +10,13 @@ import { LogBuffer } from '../buffer/manager';
 import { ConfigManager } from '../config/manager';
 import { wsManager } from '../ws/manager';
 import { resourceManager } from '../resource/manager';
+import { txAdminCompat } from '../txadmin/compat';
 
 const STARTUP_STALL_MS = 90_000;
 const KILL_GRACE_MS = 5_000;
+const SHUTDOWN_EVENT_GRACE_MS = 10_000;
+
+type ShutdownOpts = { author?: string; message?: string };
 
 export class ProcessManager {
 	private state: ServerState = {
@@ -25,9 +29,11 @@ export class ProcessManager {
 	private config = ConfigManager.getInstance();
 	private startupTimer: ReturnType<typeof setTimeout> | null = null;
 	private readonly startupStallMs: number;
+	private readonly shutdownGraceMs: number;
 
-	constructor(opts?: { startupStallMs?: number }) {
+	constructor(opts?: { startupStallMs?: number; shutdownGraceMs?: number }) {
 		this.startupStallMs = opts?.startupStallMs ?? STARTUP_STALL_MS;
+		this.shutdownGraceMs = opts?.shutdownGraceMs ?? SHUTDOWN_EVENT_GRACE_MS;
 	}
 
 	// region process methods
@@ -104,7 +110,7 @@ export class ProcessManager {
 		}
 	}
 
-	async stop() {
+	async stop(opts?: ShutdownOpts) {
 		if (
 			!this.proc ||
 			this.state.status === 'stopping' ||
@@ -113,6 +119,7 @@ export class ProcessManager {
 			return false;
 
 		const proc = this.proc;
+		const wasRunning = this.state.status === 'running';
 
 		console.log(`[core] Stopping fxServer`);
 		this.setState('stopping');
@@ -129,6 +136,8 @@ export class ProcessManager {
 				source: 'stdout',
 			} satisfies ProcessOutputLine,
 		});
+
+		if (wasRunning) await this.announceShutdown(opts);
 
 		await this.terminate(proc);
 
@@ -149,12 +158,26 @@ export class ProcessManager {
 		return true;
 	}
 
-	async restart() {
+	async restart(opts?: ShutdownOpts) {
 		if (this.state.status === 'running' || this.state.status === 'starting')
-			await this.stop();
+			await this.stop(opts);
 		await this.start();
 
 		return true;
+	}
+
+	private async announceShutdown(opts?: ShutdownOpts): Promise<void> {
+		const delay = this.shutdownGraceMs;
+
+		await txAdminCompat.emit('serverShuttingDown', {
+			delay,
+			author: opts?.author ?? 'System',
+			message: opts?.message ?? 'Server is shutting down.',
+		});
+
+		if (delay > 0) {
+			await new Promise<void>((resolve) => setTimeout(resolve, delay));
+		}
 	}
 
 	sendCommand(command: string): void {

--- a/apps/core/src/modules/resource/manager.test.ts
+++ b/apps/core/src/modules/resource/manager.test.ts
@@ -24,6 +24,10 @@ const getInstanceSpy = spyOn(ConfigManager, 'getInstance').mockReturnValue({
 	getSystemValues: mockGetSystemValues,
 } as any);
 
+mock.module('../../common/fxserver-endpoint', () => ({
+	getServerNetEndpoint: async () => '127.0.0.1:30120',
+}));
+
 // Import the system under test (SUT) after establishing the spies
 import { resourceManager } from './manager';
 

--- a/apps/core/src/modules/resource/manager.ts
+++ b/apps/core/src/modules/resource/manager.ts
@@ -5,6 +5,7 @@ import type {
 } from '@fxmanager/shared/types';
 import { wsManager } from '../ws/manager';
 import { ConfigManager } from '../config/manager';
+import { getServerNetEndpoint } from '../../common/fxserver-endpoint';
 
 class ResourceManager {
 	private config = ConfigManager.getInstance();
@@ -21,8 +22,9 @@ class ResourceManager {
 	async loadResources(): Promise<void> {
 		try {
 			const apiToken = this.getApiToken();
+			const endpoint = await getServerNetEndpoint();
 			const response = await fetch(
-				'http://localhost:30120/fxManager/resources/load',
+				`http://${endpoint}/fxManager/resources/load`,
 				{
 					method: 'GET',
 					headers: {

--- a/apps/core/src/modules/schedule/manager.test.ts
+++ b/apps/core/src/modules/schedule/manager.test.ts
@@ -1,0 +1,224 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: mocking singletons */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from 'bun:test';
+
+const mockGetMultiple = mock(() => ({
+	'restarts.enabled': 'true',
+	'restarts.times': '03:00',
+}));
+mock.module('@fxmanager/database', () => ({
+	repo: { settings: { getMultiple: mockGetMultiple } },
+}));
+
+import { txAdminCompat } from '../txadmin/compat';
+const { RestartScheduler } = await import('./manager');
+
+describe('RestartScheduler', () => {
+	let scheduler: InstanceType<typeof RestartScheduler>;
+	let pm: { getState: any; restart: any };
+	let restartMock: any;
+	let emitSpy: any;
+
+	const at = (h: number, m: number, s = 0) => new Date(2026, 0, 1, h, m, s);
+	const warnings = (seconds: number) =>
+		emitSpy.mock.calls.filter(
+			(c: any[]) =>
+				c[0] === 'scheduledRestart' && c[1].secondsRemaining === seconds,
+		);
+
+	beforeEach(() => {
+		restartMock = mock(async () => true);
+		pm = { getState: mock(() => ({ status: 'running' })), restart: restartMock };
+		emitSpy = spyOn(txAdminCompat, 'emit').mockResolvedValue(undefined);
+		mockGetMultiple.mockReturnValue({
+			'restarts.enabled': 'true',
+			'restarts.times': '03:00',
+		});
+		scheduler = new RestartScheduler();
+		scheduler.attach(pm as any);
+		scheduler.reload();
+	});
+
+	afterEach(() => {
+		emitSpy.mockRestore();
+		scheduler.stop();
+	});
+
+	it('does nothing when disabled', () => {
+		mockGetMultiple.mockReturnValue({
+			'restarts.enabled': 'false',
+			'restarts.times': '03:00',
+		});
+		scheduler.reload();
+
+		scheduler.tick(at(2, 59, 50));
+
+		expect(emitSpy).not.toHaveBeenCalled();
+		expect(restartMock).not.toHaveBeenCalled();
+	});
+
+	it('fires a scheduledRestart warning once as a threshold is crossed', () => {
+		scheduler.tick(at(2, 50, 0)); // S=600 -> fire 10-minute mark
+		scheduler.tick(at(2, 50, 30)); // S=570 -> 600 already fired
+
+		expect(warnings(600)).toHaveLength(1);
+		expect(emitSpy).toHaveBeenCalledWith('scheduledRestart', {
+			secondsRemaining: 600,
+			translatedMessage: 'Server restarting in 10 minutes',
+		});
+	});
+
+	it('does not fire warnings whose mark already passed when starting mid-window', () => {
+		scheduler.tick(at(2, 54, 55)); // S=305 init, suppress 1800/900/600
+		scheduler.tick(at(2, 55, 5)); // S=295 -> fire 300
+
+		expect(warnings(600)).toHaveLength(0);
+		expect(warnings(300)).toHaveLength(1);
+	});
+
+	it('restarts at T-0 when the server is running', () => {
+		scheduler.tick(at(2, 0, 0)); // init target 03:00
+		scheduler.tick(at(3, 0, 1)); // T-0
+
+		expect(restartMock).toHaveBeenCalledTimes(1);
+		expect(restartMock).toHaveBeenCalledWith({
+			author: 'Scheduler',
+			message: 'Scheduled restart',
+		});
+	});
+
+	it('does not restart when the server is not running', () => {
+		pm.getState.mockReturnValue({ status: 'stopped' });
+
+		scheduler.tick(at(2, 0, 0));
+		scheduler.tick(at(3, 0, 1));
+
+		expect(restartMock).not.toHaveBeenCalled();
+	});
+
+	it('skips the next daily restart (not temporary) and emits scheduledRestartSkipped', () => {
+		const res = scheduler.skipNext('admin', at(2, 0, 0));
+
+		expect(res.skipped).toBe(true);
+		expect(emitSpy).toHaveBeenCalledWith(
+			'scheduledRestartSkipped',
+			expect.objectContaining({ temporary: false, author: 'admin' }),
+		);
+
+		scheduler.tick(at(2, 0, 0));
+		scheduler.tick(at(3, 0, 1));
+
+		expect(restartMock).not.toHaveBeenCalled();
+	});
+
+	it('reports schedule status', () => {
+		const status = scheduler.getStatus(at(2, 0, 0));
+
+		expect(status).toEqual({
+			enabled: true,
+			times: ['03:00'],
+			nextRestart: new Date(2026, 0, 1, 3, 0, 0).toISOString(),
+			temporary: false,
+			skipped: false,
+		});
+	});
+
+	describe('temporary restarts', () => {
+		it('schedules a one-off restart N minutes out and reports it as temporary', () => {
+			scheduler.scheduleTemp(5, at(2, 0, 0));
+
+			const status = scheduler.getStatus(at(2, 0, 0));
+			expect(status.temporary).toBe(true);
+			expect(status.nextRestart).toBe(new Date(2026, 0, 1, 2, 5, 0).toISOString());
+		});
+
+		it('takes precedence over a later daily restart', () => {
+			// daily is 03:00 (1h away); temp +5 is sooner
+			scheduler.scheduleTemp(5, at(2, 0, 0));
+			const status = scheduler.getStatus(at(2, 0, 0));
+			expect(status.nextRestart).toBe(new Date(2026, 0, 1, 2, 5, 0).toISOString());
+		});
+
+		it('works even when the daily schedule is disabled', () => {
+			mockGetMultiple.mockReturnValue({
+				'restarts.enabled': 'false',
+				'restarts.times': '',
+			});
+			scheduler.reload();
+
+			scheduler.scheduleTemp(5, at(2, 0, 0));
+			expect(scheduler.getStatus(at(2, 0, 0)).nextRestart).toBe(
+				new Date(2026, 0, 1, 2, 5, 0).toISOString(),
+			);
+		});
+
+		it('restarts at the temp time then consumes the temp target', () => {
+			scheduler.scheduleTemp(5, at(2, 0, 0));
+			scheduler.tick(at(2, 5, 1));
+
+			expect(restartMock).toHaveBeenCalledTimes(1);
+			// temp consumed: next is the daily 03:00 again
+			expect(scheduler.getStatus(at(2, 6, 0)).temporary).toBe(false);
+		});
+
+		it('fires a warning when the temp restart is scheduled within a threshold', () => {
+			scheduler.scheduleTemp(5, at(2, 0, 0));
+			expect(emitSpy).toHaveBeenCalledWith(
+				'scheduledRestart',
+				expect.objectContaining({ secondsRemaining: 300 }),
+			);
+		});
+
+		it('skipNext cancels a pending temp restart (temporary: true)', () => {
+			scheduler.scheduleTemp(5, at(2, 0, 0));
+			const res = scheduler.skipNext('admin', at(2, 0, 30));
+
+			expect(res.skipped).toBe(true);
+			expect(emitSpy).toHaveBeenCalledWith(
+				'scheduledRestartSkipped',
+				expect.objectContaining({ temporary: true }),
+			);
+			// temp gone -> next reverts to daily
+			expect(scheduler.getStatus(at(2, 1, 0)).temporary).toBe(false);
+		});
+	});
+
+	describe('txAdmin scheduledRestart parity', () => {
+		it('fires the full txAdmin mark set with exact secondsRemaining values', () => {
+			scheduler.scheduleTemp(30, at(2, 0, 0)); // target 02:30, fires 1800 now
+			scheduler.tick(at(2, 15, 0));
+			scheduler.tick(at(2, 20, 0));
+			scheduler.tick(at(2, 25, 0));
+			scheduler.tick(at(2, 26, 0));
+			scheduler.tick(at(2, 27, 0));
+			scheduler.tick(at(2, 28, 0));
+			scheduler.tick(at(2, 29, 0));
+
+			const fired = emitSpy.mock.calls
+				.filter((c: any[]) => c[0] === 'scheduledRestart')
+				.map((c: any[]) => c[1].secondsRemaining);
+
+			expect(fired).toEqual([1800, 900, 600, 300, 240, 180, 120, 60]);
+		});
+
+		it('does not emit any non-txAdmin (sub-minute) marks', () => {
+			scheduler.scheduleTemp(2, at(2, 0, 0)); // 120s out
+			scheduler.tick(at(2, 1, 30)); // 30s remaining
+			scheduler.tick(at(2, 1, 50)); // 10s remaining
+
+			const fired = emitSpy.mock.calls
+				.filter((c: any[]) => c[0] === 'scheduledRestart')
+				.map((c: any[]) => c[1].secondsRemaining);
+
+			expect(fired).not.toContain(30);
+			expect(fired).not.toContain(10);
+		});
+	});
+});

--- a/apps/core/src/modules/schedule/manager.ts
+++ b/apps/core/src/modules/schedule/manager.ts
@@ -1,0 +1,200 @@
+import { repo } from '@fxmanager/database';
+import type { RestartScheduleStatus } from '@fxmanager/shared/types';
+import { txAdminCompat } from '../txadmin/compat';
+import {
+	WARNING_THRESHOLDS,
+	computeNextRestart,
+	formatCountdown,
+	parseTimes,
+} from './time';
+
+const TICK_MS = 1_000;
+
+interface RestartablePm {
+	getState(): { status: string };
+	restart(opts?: { author?: string; message?: string }): Promise<boolean>;
+}
+
+function minutesToHHMM(m: number): string {
+	const h = Math.floor(m / 60);
+	return `${String(h).padStart(2, '0')}:${String(m % 60).padStart(2, '0')}`;
+}
+
+type TargetKind = 'temp' | 'daily';
+
+export class RestartScheduler {
+	private pm: RestartablePm | null = null;
+	private enabled = false;
+	private minutes: number[] = [];
+	private tempTarget: number | null = null;
+	private currentTarget: number | null = null;
+	private currentKind: TargetKind | null = null;
+	private firedThresholds = new Set<number>();
+	private skippedTime: number | null = null;
+	private restarting = false;
+	private timer: ReturnType<typeof setInterval> | null = null;
+
+	attach(pm: RestartablePm): void {
+		this.pm = pm;
+	}
+
+	start(pm: RestartablePm, opts?: { tickMs?: number }): void {
+		this.attach(pm);
+		this.reload();
+		this.timer = setInterval(() => this.tick(new Date()), opts?.tickMs ?? TICK_MS);
+		this.timer.unref?.();
+	}
+
+	stop(): void {
+		if (this.timer) {
+			clearInterval(this.timer);
+			this.timer = null;
+		}
+	}
+
+	reload(): void {
+		const settings = repo.settings.getMultiple([
+			'restarts.enabled',
+			'restarts.times',
+		]);
+		this.enabled = settings['restarts.enabled'] === 'true';
+		this.minutes = parseTimes(settings['restarts.times'] ?? '');
+		this.currentTarget = null;
+		this.firedThresholds.clear();
+	}
+
+	private effectiveTarget(
+		now: Date,
+	): { at: number; kind: TargetKind } | null {
+		const nowMs = now.getTime();
+		const candidates: { at: number; kind: TargetKind }[] = [];
+
+		if (this.tempTarget !== null && this.tempTarget > nowMs) {
+			candidates.push({ at: this.tempTarget, kind: 'temp' });
+		}
+		if (this.enabled && this.minutes.length > 0) {
+			const daily = computeNextRestart(this.minutes, now);
+			if (daily) candidates.push({ at: daily.getTime(), kind: 'daily' });
+		}
+
+		if (candidates.length === 0) return null;
+		candidates.sort((a, b) => a.at - b.at);
+		return candidates[0] ?? null;
+	}
+
+	getStatus(now = new Date()): RestartScheduleStatus {
+		const next = this.effectiveTarget(now);
+		return {
+			enabled: this.enabled,
+			times: this.minutes.map(minutesToHHMM),
+			nextRestart: next ? new Date(next.at).toISOString() : null,
+			temporary: next?.kind === 'temp',
+			skipped: this.skippedTime !== null,
+		};
+	}
+
+	scheduleTemp(minutes: number, now = new Date()): { nextRestart: string } {
+		const at = now.getTime() + Math.max(1, Math.round(minutes)) * 60_000;
+		this.tempTarget = at;
+		this.currentTarget = null;
+		this.tick(now);
+		return { nextRestart: new Date(at).toISOString() };
+	}
+
+	skipNext(
+		author: string,
+		now = new Date(),
+	): { skipped: boolean; nextRestart: string | null } {
+		const next = this.effectiveTarget(now);
+		if (!next) return { skipped: false, nextRestart: null };
+
+		if (next.kind === 'temp') {
+			this.tempTarget = null;
+		} else {
+			this.skippedTime = next.at;
+		}
+		this.currentTarget = null;
+
+		const secondsRemaining = Math.max(
+			0,
+			Math.round((next.at - now.getTime()) / 1000),
+		);
+		void txAdminCompat.emit('scheduledRestartSkipped', {
+			secondsRemaining,
+			temporary: next.kind === 'temp',
+			author,
+		});
+
+		return { skipped: true, nextRestart: new Date(next.at).toISOString() };
+	}
+
+	tick(now: Date): void {
+		if (this.currentTarget === null) {
+			const next = this.effectiveTarget(now);
+			if (!next) {
+				this.currentKind = null;
+				this.firedThresholds.clear();
+				return;
+			}
+			this.setCurrentTarget(next.at, next.kind, now);
+		} else if (
+			this.tempTarget !== null &&
+			this.tempTarget > now.getTime() &&
+			this.tempTarget < this.currentTarget
+		) {
+			this.setCurrentTarget(this.tempTarget, 'temp', now);
+		}
+
+		const target = this.currentTarget;
+		if (target === null) return;
+
+		const secondsRemaining = (target - now.getTime()) / 1000;
+
+		if (secondsRemaining <= 0) {
+			if (this.skippedTime === target) {
+				this.skippedTime = null;
+			} else if (
+				!this.restarting &&
+				this.pm?.getState().status === 'running'
+			) {
+				this.triggerRestart();
+			}
+			if (this.currentKind === 'temp') this.tempTarget = null;
+			this.currentTarget = null;
+			return;
+		}
+
+		if (this.skippedTime === target) return;
+
+		for (const threshold of WARNING_THRESHOLDS) {
+			if (secondsRemaining <= threshold && !this.firedThresholds.has(threshold)) {
+				this.firedThresholds.add(threshold);
+				void txAdminCompat.emit('scheduledRestart', {
+					secondsRemaining: threshold,
+					translatedMessage: formatCountdown(threshold),
+				});
+			}
+		}
+	}
+
+	private setCurrentTarget(at: number, kind: TargetKind, now: Date): void {
+		this.currentTarget = at;
+		this.currentKind = kind;
+		this.firedThresholds.clear();
+		const initial = (at - now.getTime()) / 1000;
+		for (const threshold of WARNING_THRESHOLDS) {
+			if (threshold > initial) this.firedThresholds.add(threshold);
+		}
+	}
+
+	private triggerRestart(): void {
+		this.restarting = true;
+		void this.pm
+			?.restart({ author: 'Scheduler', message: 'Scheduled restart' })
+			.finally(() => {
+				this.restarting = false;
+			});
+	}
+}
+
+export const restartScheduler = new RestartScheduler();

--- a/apps/core/src/modules/schedule/time.test.ts
+++ b/apps/core/src/modules/schedule/time.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'bun:test';
+import {
+	WARNING_THRESHOLDS,
+	computeNextRestart,
+	formatCountdown,
+	parseTimes,
+} from './time';
+
+describe('parseTimes', () => {
+	it('parses HH:MM into sorted minutes-since-midnight', () => {
+		expect(parseTimes('15:00,03:00')).toEqual([180, 900]);
+	});
+
+	it('ignores malformed, out-of-range, and empty entries', () => {
+		expect(parseTimes('bad,25:00,03:60,03:00,, ')).toEqual([180]);
+	});
+
+	it('returns an empty array for an empty string', () => {
+		expect(parseTimes('')).toEqual([]);
+	});
+
+	it('dedupes repeated times', () => {
+		expect(parseTimes('03:00,03:00')).toEqual([180]);
+	});
+});
+
+describe('computeNextRestart', () => {
+	it('picks the next time later today', () => {
+		const now = new Date(2026, 0, 1, 2, 0, 0);
+		expect(computeNextRestart([180], now)).toEqual(new Date(2026, 0, 1, 3, 0, 0));
+	});
+
+	it('rolls to tomorrow when every time today has passed', () => {
+		const now = new Date(2026, 0, 1, 4, 0, 0);
+		expect(computeNextRestart([180], now)).toEqual(new Date(2026, 0, 2, 3, 0, 0));
+	});
+
+	it('chooses the earliest upcoming among several times', () => {
+		const now = new Date(2026, 0, 1, 2, 0, 0);
+		// 01:00 already passed -> tomorrow; 03:00 today is the soonest
+		expect(computeNextRestart([60, 180], now)).toEqual(
+			new Date(2026, 0, 1, 3, 0, 0),
+		);
+	});
+
+	it('treats an exact match as passed (advances)', () => {
+		const now = new Date(2026, 0, 1, 3, 0, 0);
+		expect(computeNextRestart([180], now)).toEqual(new Date(2026, 0, 2, 3, 0, 0));
+	});
+
+	it('returns null with no times', () => {
+		expect(computeNextRestart([], new Date())).toBeNull();
+	});
+});
+
+describe('formatCountdown', () => {
+	it('formats whole minutes', () => {
+		expect(formatCountdown(300)).toBe('Server restarting in 5 minutes');
+		expect(formatCountdown(60)).toBe('Server restarting in 1 minute');
+		expect(formatCountdown(1800)).toBe('Server restarting in 30 minutes');
+	});
+
+	it('formats sub-minute marks in seconds', () => {
+		expect(formatCountdown(30)).toBe('Server restarting in 30 seconds');
+		expect(formatCountdown(10)).toBe('Server restarting in 10 seconds');
+	});
+});
+
+describe('WARNING_THRESHOLDS', () => {
+	it('matches txAdmin marks: [30,15,10,5,4,3,2,1] minutes in seconds', () => {
+		expect(WARNING_THRESHOLDS).toEqual([1800, 900, 600, 300, 240, 180, 120, 60]);
+	});
+});

--- a/apps/core/src/modules/schedule/time.ts
+++ b/apps/core/src/modules/schedule/time.ts
@@ -1,0 +1,45 @@
+export const WARNING_THRESHOLDS = [
+	1800, 900, 600, 300, 240, 180, 120, 60,
+] as const;
+
+const TIME_RE = /^(\d{1,2}):(\d{2})$/;
+
+export function parseTimes(csv: string): number[] {
+	const minutes = new Set<number>();
+
+	for (const raw of csv.split(',')) {
+		const match = TIME_RE.exec(raw.trim());
+		if (!match) continue;
+
+		const hours = Number(match[1]);
+		const mins = Number(match[2]);
+		if (hours > 23 || mins > 59) continue;
+
+		minutes.add(hours * 60 + mins);
+	}
+
+	return [...minutes].sort((a, b) => a - b);
+}
+
+export function computeNextRestart(minutes: number[], now: Date): Date | null {
+	let best: Date | null = null;
+
+	for (const m of minutes) {
+		const candidate = new Date(now);
+		candidate.setHours(Math.floor(m / 60), m % 60, 0, 0);
+		if (candidate.getTime() <= now.getTime()) {
+			candidate.setDate(candidate.getDate() + 1);
+		}
+		if (!best || candidate.getTime() < best.getTime()) best = candidate;
+	}
+
+	return best;
+}
+
+export function formatCountdown(seconds: number): string {
+	if (seconds >= 60 && seconds % 60 === 0) {
+		const m = seconds / 60;
+		return `Server restarting in ${m} minute${m === 1 ? '' : 's'}`;
+	}
+	return `Server restarting in ${seconds} second${seconds === 1 ? '' : 's'}`;
+}

--- a/apps/core/src/modules/txadmin/compat.test.ts
+++ b/apps/core/src/modules/txadmin/compat.test.ts
@@ -1,0 +1,90 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: mocking singletons and fetch */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from 'bun:test';
+
+mock.module('@fxmanager/database', () => ({ repo: {} }));
+mock.module('../../common/fxserver-endpoint', () => ({
+	getServerNetEndpoint: async () => '127.0.0.1:30120',
+}));
+
+import { ConfigManager } from '../config/manager';
+const { txAdminCompat } = await import('./compat');
+
+describe('txAdminCompat.emit', () => {
+	const originalFetch = global.fetch;
+
+	beforeEach(() => {
+		spyOn(ConfigManager, 'getInstance').mockReturnValue({
+			getSystemValues: () => ({ resourceApiToken: 'mock-token' }),
+		} as any);
+	});
+
+	afterEach(() => {
+		global.fetch = originalFetch;
+		mock.restore();
+	});
+
+	it('POSTs the event envelope to the resource with the api token', async () => {
+		global.fetch = mock(async () => ({ ok: true }) as Response) as any;
+
+		await txAdminCompat.emit('serverShuttingDown', {
+			delay: 1000,
+			author: 'admin',
+			message: 'bye',
+		});
+
+		expect(global.fetch).toHaveBeenCalledWith(
+			'http://127.0.0.1:30120/fxManager/txadmin/event',
+			{
+				method: 'POST',
+				body: JSON.stringify({
+					event: 'serverShuttingDown',
+					data: { delay: 1000, author: 'admin', message: 'bye' },
+				}),
+				headers: {
+					Application: 'json/application',
+					'x-resource-token': 'mock-token',
+				},
+			},
+		);
+	});
+
+	it('resolves without throwing when the resource is unreachable', async () => {
+		global.fetch = mock(async () => {
+			throw new Error('Connection Refused');
+		}) as any;
+
+		await expect(
+			txAdminCompat.emit('playerKicked', {
+				target: 3,
+				author: 'admin',
+				reason: 'x',
+				dropMessage: 'y',
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	it('does not throw when the resource responds non-ok', async () => {
+		global.fetch = mock(
+			async () => ({ ok: false, status: 401, statusText: 'Unauthorized' }) as Response,
+		) as any;
+
+		await expect(
+			txAdminCompat.emit('playerWarned', {
+				author: 'admin',
+				reason: 'x',
+				actionId: '1',
+				targetNetId: 3,
+				targetIds: ['license:abc'],
+				targetName: 'Bob',
+			}),
+		).resolves.toBeUndefined();
+	});
+});

--- a/apps/core/src/modules/txadmin/compat.ts
+++ b/apps/core/src/modules/txadmin/compat.ts
@@ -1,0 +1,41 @@
+import type { TxEventName, TxEventPayloads } from '@fxmanager/shared/types';
+import { getServerNetEndpoint } from '../../common/fxserver-endpoint';
+import { ConfigManager } from '../config/manager';
+
+export class TxAdminCompat {
+	async emit<E extends TxEventName>(
+		event: E,
+		data: TxEventPayloads[E],
+	): Promise<void> {
+		try {
+			const { resourceApiToken } =
+				ConfigManager.getInstance().getSystemValues();
+			const endpoint = await getServerNetEndpoint();
+
+			const response = await fetch(
+				`http://${endpoint}/fxManager/txadmin/event`,
+				{
+					method: 'POST',
+					body: JSON.stringify({ event, data }),
+					headers: {
+						Application: 'json/application',
+						'x-resource-token': resourceApiToken,
+					},
+				},
+			);
+
+			if (!response.ok) {
+				console.error(
+					`[txAdminCompat] resource rejected '${event}': ${response.status} ${response.statusText}`,
+				);
+			}
+		} catch (err) {
+			console.error(
+				`[txAdminCompat] failed to relay '${event}':`,
+				(err as Error).message,
+			);
+		}
+	}
+}
+
+export const txAdminCompat = new TxAdminCompat();

--- a/apps/core/src/modules/txadmin/payloads.test.ts
+++ b/apps/core/src/modules/txadmin/payloads.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'bun:test';
+import {
+	buildBannedPayload,
+	buildWarnedPayload,
+	identifiersToTxIds,
+} from './payloads';
+
+describe('identifiersToTxIds', () => {
+	it('returns the prefixed identifier strings', () => {
+		expect(
+			identifiersToTxIds({
+				license: 'license:abc',
+				discord: 'discord:123',
+			}),
+		).toEqual(['license:abc', 'discord:123']);
+	});
+
+	it('drops empty and missing identifiers', () => {
+		expect(
+			identifiersToTxIds({ license: 'license:abc', steam: '' }),
+		).toEqual(['license:abc']);
+	});
+
+	it('returns an empty array when no identifiers are known', () => {
+		expect(identifiersToTxIds(undefined)).toEqual([]);
+	});
+});
+
+describe('buildBannedPayload', () => {
+	const base = {
+		author: 'Maximus',
+		reason: 'cheating',
+		banId: 42,
+		targetNetId: 7,
+		targetName: 'Bob',
+		identifiers: { license: 'license:abc' },
+		kickMessage: 'You are banned',
+	};
+
+	it('encodes a temporary ban expiry as unix seconds', () => {
+		const payload = buildBannedPayload({
+			...base,
+			expiresAt: new Date('2030-01-01T00:00:00.000Z'),
+		});
+
+		expect(payload.expiration).toBe(1893456000);
+		expect(payload.actionId).toBe('42');
+		expect(payload.targetIds).toEqual(['license:abc']);
+		expect(payload.targetHwids).toEqual([]);
+		expect(payload.targetNetId).toBe(7);
+		expect(payload.kickMessage).toBe('You are banned');
+	});
+
+	it('encodes a permanent ban expiry as false', () => {
+		const payload = buildBannedPayload({ ...base, expiresAt: null });
+		expect(payload.expiration).toBe(false);
+	});
+
+	it('uses a null targetNetId for an offline ban', () => {
+		const payload = buildBannedPayload({
+			...base,
+			expiresAt: null,
+			targetNetId: null,
+		});
+		expect(payload.targetNetId).toBeNull();
+	});
+
+	it('falls back to an empty action id when none is available', () => {
+		const payload = buildBannedPayload({
+			...base,
+			banId: undefined,
+			expiresAt: null,
+		});
+		expect(payload.actionId).toBe('');
+	});
+});
+
+describe('buildWarnedPayload', () => {
+	it('builds the warned payload with a stringified action id', () => {
+		const payload = buildWarnedPayload({
+			author: 'Maximus',
+			reason: 'spam',
+			warnId: 9,
+			targetNetId: null,
+			targetName: 'Bob',
+			identifiers: { license: 'license:abc', discord: 'discord:1' },
+		});
+
+		expect(payload.actionId).toBe('9');
+		expect(payload.targetIds).toEqual(['license:abc', 'discord:1']);
+		expect(payload.targetNetId).toBeNull();
+		expect(payload.targetName).toBe('Bob');
+	});
+});

--- a/apps/core/src/modules/txadmin/payloads.ts
+++ b/apps/core/src/modules/txadmin/payloads.ts
@@ -1,0 +1,62 @@
+import type {
+	PlayerIdentifiers,
+	TxEventPayloads,
+} from '@fxmanager/shared/types';
+
+export function identifiersToTxIds(
+	identifiers?: Partial<PlayerIdentifiers>,
+): string[] {
+	if (!identifiers) return [];
+	return Object.values(identifiers).filter(
+		(value): value is string => typeof value === 'string' && value.length > 0,
+	);
+}
+
+function toActionId(id: number | undefined): string {
+	return id === undefined ? '' : String(id);
+}
+
+export function buildBannedPayload(args: {
+	author: string;
+	reason: string;
+	banId: number | undefined;
+	expiresAt: Date | null;
+	targetNetId: number | null;
+	targetName: string;
+	identifiers?: Partial<PlayerIdentifiers>;
+	kickMessage: string;
+}): TxEventPayloads['playerBanned'] {
+	return {
+		author: args.author,
+		reason: args.reason,
+		actionId: toActionId(args.banId),
+		expiration: args.expiresAt
+			? Math.floor(args.expiresAt.getTime() / 1000)
+			: false,
+		durationInput: '',
+		durationTranslated: null,
+		targetNetId: args.targetNetId,
+		targetIds: identifiersToTxIds(args.identifiers),
+		targetHwids: [],
+		targetName: args.targetName,
+		kickMessage: args.kickMessage,
+	};
+}
+
+export function buildWarnedPayload(args: {
+	author: string;
+	reason: string;
+	warnId: number | undefined;
+	targetNetId: number | null;
+	targetName: string;
+	identifiers?: Partial<PlayerIdentifiers>;
+}): TxEventPayloads['playerWarned'] {
+	return {
+		author: args.author,
+		reason: args.reason,
+		actionId: toActionId(args.warnId),
+		targetNetId: args.targetNetId,
+		targetIds: identifiersToTxIds(args.identifiers),
+		targetName: args.targetName,
+	};
+}

--- a/apps/core/src/routes/api/players.ts
+++ b/apps/core/src/routes/api/players.ts
@@ -8,6 +8,11 @@ import { PermissionManager } from '@fxmanager/shared/utils';
 import { UserPermissions } from '@fxmanager/shared/constants';
 import { repo } from '@fxmanager/database';
 import type { PaginatedResponse, Player } from '@fxmanager/shared/types';
+import { txAdminCompat } from '../../modules/txadmin/compat';
+import {
+	buildBannedPayload,
+	buildWarnedPayload,
+} from '../../modules/txadmin/payloads';
 
 const PlayerEndpoints: RouteModule['handler'] = async (fastify, options) => {
 	const { gm } = options;
@@ -138,16 +143,30 @@ const PlayerEndpoints: RouteModule['handler'] = async (fastify, options) => {
 			});
 
 			const onlinePlayer = gm.getPlayer(playerId);
+			const expiryDate = expiresAt
+				? new Date(expiresAt).toLocaleString()
+				: 'Permanent';
+
+			const kickMessage = `You have been banned from the server. Reason: ${reason}. Expires: ${expiryDate}`;
+
 			if (onlinePlayer) {
-				const expiryDate = expiresAt
-					? new Date(expiresAt).toLocaleString()
-					: 'Permanent';
-
-				// apparently drop modal in fivem/redm doesn't support new lines ?
-				const kickMessage = `You have been banned from the server. Reason: ${reason}. Expires: ${expiryDate}`;
-
 				await gm.dropPlayer(onlinePlayer.serverId, kickMessage);
 			}
+
+			const profile = onlinePlayer ?? (await repo.players.findById(playerId));
+			void txAdminCompat.emit(
+				'playerBanned',
+				buildBannedPayload({
+					author: admin.username,
+					reason,
+					banId: result.id,
+					expiresAt,
+					targetNetId: onlinePlayer?.serverId ?? null,
+					targetName: profile?.name ?? 'Unknown',
+					identifiers: profile?.identifiers,
+					kickMessage,
+				}),
+			);
 
 			return {
 				success: true,
@@ -213,6 +232,13 @@ const PlayerEndpoints: RouteModule['handler'] = async (fastify, options) => {
 			const kickMessage = `You have been kicked from the server. Reason: ${reason}`;
 			await gm.dropPlayer(onlinePlayer.serverId, kickMessage);
 
+			void txAdminCompat.emit('playerKicked', {
+				target: onlinePlayer.serverId,
+				author: admin.username,
+				reason,
+				dropMessage: kickMessage,
+			});
+
 			return {
 				success: true,
 				data: null,
@@ -261,6 +287,20 @@ const PlayerEndpoints: RouteModule['handler'] = async (fastify, options) => {
 			// ToDo: warn player in game
 			// - needs to be able to be done offline so on connection he receives it
 			// await gm.warnPlayer(playerId, reason)
+
+			const onlinePlayer = gm.getPlayer(playerId);
+			const profile = onlinePlayer ?? (await repo.players.findById(playerId));
+			void txAdminCompat.emit(
+				'playerWarned',
+				buildWarnedPayload({
+					author: admin.username,
+					reason,
+					warnId: result.id,
+					targetNetId: onlinePlayer?.serverId ?? null,
+					targetName: profile?.name ?? 'Unknown',
+					identifiers: profile?.identifiers,
+				}),
+			);
 
 			return {
 				success: true,

--- a/apps/core/src/routes/api/server.ts
+++ b/apps/core/src/routes/api/server.ts
@@ -5,6 +5,7 @@ import type { AuthedRequest, RouteModule } from '../../types';
 import { sessionAuth } from '../../middleware/session';
 import { resourceManager } from '../../modules/resource/manager';
 import { getRecommendedArtifact } from '../../common/recommended-artifact';
+import { restartScheduler } from '../../modules/schedule/manager';
 
 const ServerEndpoints: RouteModule['handler'] = async (fastify, options) => {
 	const { pm } = options;
@@ -47,7 +48,10 @@ const ServerEndpoints: RouteModule['handler'] = async (fastify, options) => {
 			return reply.code(403).send({ error: 'Not authorized' });
 		}
 
-		const result = await pm.stop();
+		const result = await pm.stop({
+			author: admin.username,
+			message: 'Server stopped by an admin.',
+		});
 
 		repo.audit.log({
 			adminId: admin.id,
@@ -70,7 +74,10 @@ const ServerEndpoints: RouteModule['handler'] = async (fastify, options) => {
 			return reply.code(403).send({ error: 'Not authorized' });
 		}
 
-		const result = await pm.restart();
+		const result = await pm.restart({
+			author: admin.username,
+			message: 'Server is restarting.',
+		});
 
 		repo.audit.log({
 			adminId: admin.id,
@@ -155,6 +162,74 @@ const ServerEndpoints: RouteModule['handler'] = async (fastify, options) => {
 		await resourceManager.loadResources();
 
 		return reply.code(200).send({ success: true });
+	});
+
+	fastify.get('/schedule', async (request, reply) => {
+		const { admin } = request as AuthedRequest;
+
+		if (
+			!PermissionManager.has(admin.permissions, UserPermissions.SERVER_ACTIONS)
+		) {
+			return reply.code(403).send({ error: 'Not authorized' });
+		}
+
+		return reply
+			.code(200)
+			.send({ success: true, data: restartScheduler.getStatus() });
+	});
+
+	fastify.post('/schedule/skip', async (request, reply) => {
+		const { admin } = request as AuthedRequest;
+
+		if (
+			!PermissionManager.has(admin.permissions, UserPermissions.SERVER_ACTIONS)
+		) {
+			return reply.code(403).send({ error: 'Not authorized' });
+		}
+
+		const result = restartScheduler.skipNext(admin.username);
+
+		if (result.skipped) {
+			repo.audit.log({
+				adminId: admin.id,
+				action: 'server.restart',
+				metadata: { skippedScheduledRestart: result.nextRestart },
+			});
+		}
+
+		return reply.code(200).send({ success: true, data: result });
+	});
+
+	fastify.post('/schedule/restart-in', async (request, reply) => {
+		const { admin } = request as AuthedRequest;
+
+		if (
+			!PermissionManager.has(admin.permissions, UserPermissions.SERVER_ACTIONS)
+		) {
+			return reply.code(403).send({ error: 'Not authorized' });
+		}
+
+		const { minutes } = request.body as { minutes?: number };
+		if (
+			typeof minutes !== 'number' ||
+			!Number.isFinite(minutes) ||
+			minutes < 1 ||
+			minutes > 1440
+		) {
+			return reply
+				.code(400)
+				.send({ success: false, error: 'minutes must be between 1 and 1440' });
+		}
+
+		const result = restartScheduler.scheduleTemp(Math.round(minutes));
+
+		repo.audit.log({
+			adminId: admin.id,
+			action: 'server.restart',
+			metadata: { temporaryRestartIn: minutes, at: result.nextRestart },
+		});
+
+		return reply.code(200).send({ success: true, data: result });
 	});
 };
 

--- a/apps/core/src/routes/api/settings/index.ts
+++ b/apps/core/src/routes/api/settings/index.ts
@@ -14,6 +14,7 @@ import {
 	UserPermissions,
 } from '@fxmanager/shared/constants';
 import { repo } from '@fxmanager/database';
+import { restartScheduler } from '../../../modules/schedule/manager';
 
 const SettingsEndpoints: RouteModule['handler'] = async (
 	fastify,
@@ -74,6 +75,9 @@ const SettingsEndpoints: RouteModule['handler'] = async (
 		}
 
 		repo.settings.set(key, value);
+
+		if (scope === 'restarts') restartScheduler.reload();
+
 		return { success: true, data: undefined };
 	});
 

--- a/apps/resource/src/server/httphandler/index.ts
+++ b/apps/resource/src/server/httphandler/index.ts
@@ -2,6 +2,7 @@ import z from 'zod';
 import { API_TOKEN } from '../utils/env';
 import { HttpServer } from './class';
 import { getResourcesData } from '../utils/resources';
+import { handleTxEvent, txEventSchema } from '../txadmin/handler';
 
 const api = new HttpServer(API_TOKEN);
 
@@ -39,5 +40,9 @@ api.get('/server/version', () => {
 		body: { success: true, data: GetConvar('version', 'unknown') },
 	};
 });
+
+api.post('/txadmin/event', { schema: txEventSchema }, ({ body }) =>
+	handleTxEvent(body),
+);
 
 console.log('Webserver initialized');

--- a/apps/resource/src/server/index.ts
+++ b/apps/resource/src/server/index.ts
@@ -1,2 +1,3 @@
+import './txadmin';
 import './events';
 import './httphandler';

--- a/apps/resource/src/server/monitoring/players.test.ts
+++ b/apps/resource/src/server/monitoring/players.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, expect, test } from 'bun:test';
+
+type Globalish = Record<string, unknown>;
+const g = globalThis as Globalish;
+
+g.GetConvar = (key: string, def: string) =>
+	key === 'resource-api-token' ? '00000000-0000-4000-8000-000000000000' : def;
+g.GetConvarInt = (_key: string, def: number) => def;
+
+const { playerManager } = await import('./players');
+
+type WithPlayers = { players: Map<string, unknown> };
+const setPlayers = (entries: string[]) => {
+	(playerManager as unknown as WithPlayers).players = new Map(
+		entries.map((id) => [id, { permissions: 0 }]),
+	);
+};
+
+const originalDropPlayer = g.DropPlayer;
+afterEach(() => {
+	g.DropPlayer = originalDropPlayer;
+	setPlayers([]);
+});
+
+test('dropAll disconnects every tracked player with the reason', () => {
+	setPlayers(['1', '2', '3']);
+	const drops: Array<[string, string]> = [];
+	g.DropPlayer = (id: string, reason: string) => drops.push([id, reason]);
+
+	const count = playerManager.dropAll('Server is restarting.');
+
+	expect(count).toBe(3);
+	expect(drops).toEqual([
+		['1', 'Server is restarting.'],
+		['2', 'Server is restarting.'],
+		['3', 'Server is restarting.'],
+	]);
+});
+
+test('dropAll returns 0 when nobody is connected', () => {
+	setPlayers([]);
+	const drops: string[] = [];
+	g.DropPlayer = (id: string) => drops.push(id);
+
+	expect(playerManager.dropAll('bye')).toBe(0);
+	expect(drops).toEqual([]);
+});

--- a/apps/resource/src/server/monitoring/players.ts
+++ b/apps/resource/src/server/monitoring/players.ts
@@ -15,6 +15,12 @@ class PlayerManager {
 		if (this.players.size === 0) this.clearUpdates();
 	}
 
+	dropAll(reason: string): number {
+		const ids = [...this.players.keys()];
+		for (const id of ids) DropPlayer(id, reason);
+		return ids.length;
+	}
+
 	private startUpdates() {
 		this.updateInterval = setInterval(async () => {
 			const updatePacket: PlayerUpdatePackage = {};

--- a/apps/resource/src/server/txadmin/chat.test.ts
+++ b/apps/resource/src/server/txadmin/chat.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from 'bun:test';
+
+type Globalish = Record<string, unknown>;
+const g = globalThis as Globalish;
+
+const handlers: Record<string, (data: unknown) => void> = {};
+g.on = (event: string, cb: (data: unknown) => void) => {
+	handlers[event] = cb;
+};
+
+await import('./chat');
+
+type ChatArgs = [string, number, { color: number[]; args: string[] }];
+
+test('scheduledRestart posts the translatedMessage to chat', () => {
+	const sent: ChatArgs[] = [];
+	g.emitNet = (...args: ChatArgs) => sent.push(args);
+
+	handlers['txAdmin:events:scheduledRestart']?.({
+		secondsRemaining: 300,
+		translatedMessage: 'Server restarting in 5 minutes',
+	});
+
+	expect(sent[0]?.[0]).toBe('chat:addMessage');
+	expect(sent[0]?.[1]).toBe(-1);
+	expect(sent[0]?.[2].args).toEqual([
+		'fxManager',
+		'Server restarting in 5 minutes',
+	]);
+});
+
+test('scheduledRestartSkipped posts a cancellation message naming the author', () => {
+	const sent: ChatArgs[] = [];
+	g.emitNet = (...args: ChatArgs) => sent.push(args);
+
+	handlers['txAdmin:events:scheduledRestartSkipped']?.({
+		secondsRemaining: 100,
+		temporary: true,
+		author: 'admin',
+	});
+
+	expect(sent[0]?.[2].args).toEqual([
+		'fxManager',
+		'Scheduled restart cancelled by admin',
+	]);
+});

--- a/apps/resource/src/server/txadmin/chat.ts
+++ b/apps/resource/src/server/txadmin/chat.ts
@@ -1,0 +1,17 @@
+const CHAT_COLOR = [255, 165, 0];
+
+function postChat(message: string): void {
+	emitNet('chat:addMessage', -1, {
+		color: CHAT_COLOR,
+		args: ['fxManager', message],
+	});
+}
+
+on('txAdmin:events:scheduledRestart', (data: { translatedMessage?: string }) => {
+	if (data?.translatedMessage) postChat(data.translatedMessage);
+});
+
+on('txAdmin:events:scheduledRestartSkipped', (data: { author?: string }) => {
+	const by = data?.author ? ` by ${data.author}` : '';
+	postChat(`Scheduled restart cancelled${by}`);
+});

--- a/apps/resource/src/server/txadmin/emitter.test.ts
+++ b/apps/resource/src/server/txadmin/emitter.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, expect, test } from 'bun:test';
+import { emitTxEvent } from './emitter';
+
+type Globalish = Record<string, unknown>;
+const originalEmit = (globalThis as Globalish).emit;
+
+afterEach(() => {
+	(globalThis as Globalish).emit = originalEmit;
+});
+
+test('emitTxEvent emits the prefixed txAdmin event name with the payload', () => {
+	const calls: Array<[string, unknown]> = [];
+	(globalThis as Globalish).emit = (name: string, data: unknown) => {
+		calls.push([name, data]);
+	};
+
+	const payload = { delay: 1000, author: 'admin', message: 'Restarting' };
+	emitTxEvent('serverShuttingDown', payload);
+
+	expect(calls).toHaveLength(1);
+	expect(calls[0]?.[0]).toBe('txAdmin:events:serverShuttingDown');
+	expect(calls[0]?.[1]).toEqual(payload);
+});
+
+test('emitTxEvent forwards player event payloads untouched', () => {
+	const calls: Array<[string, unknown]> = [];
+	(globalThis as Globalish).emit = (name: string, data: unknown) => {
+		calls.push([name, data]);
+	};
+
+	const payload = {
+		target: 3,
+		author: 'admin',
+		reason: 'rule break',
+		dropMessage: 'You were kicked',
+	};
+	emitTxEvent('playerKicked', payload);
+
+	expect(calls[0]?.[0]).toBe('txAdmin:events:playerKicked');
+	expect(calls[0]?.[1]).toEqual(payload);
+});

--- a/apps/resource/src/server/txadmin/emitter.ts
+++ b/apps/resource/src/server/txadmin/emitter.ts
@@ -1,0 +1,15 @@
+import {
+	TX_EVENT_PREFIX,
+	type TxEventName,
+	type TxEventPayloads,
+} from '@fxmanager/shared/types';
+
+/**
+ * Emits a backwards compatible txAdmin event across the server for compatability
+ */
+export function emitTxEvent<E extends TxEventName>(
+	event: E,
+	data: TxEventPayloads[E],
+): void {
+	emit(`${TX_EVENT_PREFIX}${event}`, data);
+}

--- a/apps/resource/src/server/txadmin/handler.test.ts
+++ b/apps/resource/src/server/txadmin/handler.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, expect, test } from 'bun:test';
+import { handleTxEvent, txEventSchema } from './handler';
+
+type Globalish = Record<string, unknown>;
+const originalEmit = (globalThis as Globalish).emit;
+
+afterEach(() => {
+	(globalThis as Globalish).emit = originalEmit;
+});
+
+test('handleTxEvent emits the event and returns a success response', () => {
+	const calls: Array<[string, unknown]> = [];
+	(globalThis as Globalish).emit = (name: string, data: unknown) => {
+		calls.push([name, data]);
+	};
+
+	const res = handleTxEvent({
+		event: 'announcement',
+		data: { author: 'admin', message: 'hi' },
+	});
+
+	expect(calls[0]?.[0]).toBe('txAdmin:events:announcement');
+	expect(res.status).toBe(200);
+	expect(res.body).toEqual({ success: true, data: null });
+});
+
+test('txEventSchema accepts a known event name', () => {
+	const result = txEventSchema.safeParse({
+		event: 'serverShuttingDown',
+		data: { delay: 1000, author: 'admin', message: 'bye' },
+	});
+	expect(result.success).toBe(true);
+});
+
+test('txEventSchema rejects an unknown event name', () => {
+	const result = txEventSchema.safeParse({ event: 'notATxEvent', data: {} });
+	expect(result.success).toBe(false);
+});

--- a/apps/resource/src/server/txadmin/handler.ts
+++ b/apps/resource/src/server/txadmin/handler.ts
@@ -1,0 +1,23 @@
+import {
+	TX_EVENT_NAMES,
+	type TxEventPayloads,
+} from '@fxmanager/shared/types';
+import { z } from 'zod';
+import type { HttpResponse } from '../types';
+import { emitTxEvent } from './emitter';
+
+export const txEventSchema = z.object({
+	event: z.enum(TX_EVENT_NAMES),
+	data: z.unknown(),
+});
+
+export type TxEventRequest = z.infer<typeof txEventSchema>;
+
+export function handleTxEvent(body: TxEventRequest): HttpResponse {
+	emitTxEvent(body.event, body.data as TxEventPayloads[typeof body.event]);
+
+	return {
+		status: 200,
+		body: { success: true, data: null },
+	};
+}

--- a/apps/resource/src/server/txadmin/index.ts
+++ b/apps/resource/src/server/txadmin/index.ts
@@ -1,0 +1,2 @@
+import './chat';
+import './shutdown';

--- a/apps/resource/src/server/txadmin/shutdown.test.ts
+++ b/apps/resource/src/server/txadmin/shutdown.test.ts
@@ -1,0 +1,34 @@
+import { expect, spyOn, test } from 'bun:test';
+
+type Globalish = Record<string, unknown>;
+const g = globalThis as Globalish;
+
+g.GetConvar = (key: string, def: string) =>
+	key === 'resource-api-token' ? '00000000-0000-4000-8000-000000000000' : def;
+g.GetConvarInt = (_key: string, def: number) => def;
+
+const handlers: Record<string, (data: unknown) => void> = {};
+g.on = (event: string, cb: (data: unknown) => void) => {
+	handlers[event] = cb;
+};
+
+const { playerManager } = await import('../monitoring');
+await import('./shutdown');
+
+test('serverShuttingDown disconnects everyone with the message', () => {
+	const spy = spyOn(playerManager, 'dropAll').mockReturnValue(0);
+
+	handlers['txAdmin:events:serverShuttingDown']?.({ message: 'Restarting' });
+
+	expect(spy).toHaveBeenCalledWith('Restarting');
+	spy.mockRestore();
+});
+
+test('serverShuttingDown falls back to a default reason', () => {
+	const spy = spyOn(playerManager, 'dropAll').mockReturnValue(0);
+
+	handlers['txAdmin:events:serverShuttingDown']?.({});
+
+	expect(spy).toHaveBeenCalledWith('Server is shutting down.');
+	spy.mockRestore();
+});

--- a/apps/resource/src/server/txadmin/shutdown.ts
+++ b/apps/resource/src/server/txadmin/shutdown.ts
@@ -1,0 +1,8 @@
+import { playerManager } from '../monitoring';
+
+const TX_SERVER_SHUTTING_DOWN = 'txAdmin:events:serverShuttingDown';
+const DEFAULT_REASON = 'Server is shutting down.';
+
+on(TX_SERVER_SHUTTING_DOWN, (data: { message?: string }) => {
+	playerManager.dropAll(data?.message ?? DEFAULT_REASON);
+});

--- a/apps/webpanel/src/components/sidebar/server-status.tsx
+++ b/apps/webpanel/src/components/sidebar/server-status.tsx
@@ -25,6 +25,21 @@ import {
 import { HandleServerAction } from '@/lib/query';
 import { usePlayerlistSocket, useServerStateSocket } from '@/hooks/ws-channels';
 import { useRecommendedArtifact } from '@/hooks/use-recommended-artifact';
+import { useSchedule } from '@/hooks/use-schedule';
+import { useEffect, useState } from 'react';
+
+const TEMP_PRESETS = [5, 15, 30] as const;
+
+function formatRemaining(ms: number): string {
+	if (ms <= 0) return 'now';
+	const total = Math.floor(ms / 1000);
+	const h = Math.floor(total / 3600);
+	const m = Math.floor((total % 3600) / 60);
+	const s = total % 60;
+	if (h > 0) return `${h}h ${m}m`;
+	if (m > 0) return `${m}m ${s}s`;
+	return `${s}s`;
+}
 
 interface ActionButtonProps {
 	Icon: LucideIcon;
@@ -70,11 +85,23 @@ export function ServerStatusCard() {
 	const { count } = usePlayerlistSocket();
 	const recommendedArtifact = useRecommendedArtifact();
 	const { state: sideBarState, setOpen } = useSidebar();
+	const { status: schedule, restartIn, skip } = useSchedule();
 	const isCollapsed = sideBarState === 'collapsed';
 	const canStart =
 		serverState.status === 'stopped' || serverState.status === 'crashed';
 	const canStop =
 		serverState.status === 'running' || serverState.status === 'starting';
+
+	const [now, setNow] = useState(() => Date.now());
+	useEffect(() => {
+		const id = setInterval(() => setNow(Date.now()), 1000);
+		return () => clearInterval(id);
+	}, []);
+
+	const nextRestartMs = schedule?.nextRestart
+		? new Date(schedule.nextRestart).getTime() - now
+		: null;
+	const hasUpcomingRestart = nextRestartMs !== null;
 
 	if (isCollapsed) {
 		return (
@@ -112,6 +139,21 @@ export function ServerStatusCard() {
 						<p>Players:</p>
 						<p>{count}</p>
 					</div>
+					<div className="flex flex-row justify-between">
+						<p>Next restart</p>
+						<p className="tabular-nums">
+							{hasUpcomingRestart ? (
+								<>
+									in {formatRemaining(nextRestartMs)}
+									{schedule?.temporary && (
+										<span className="text-muted-foreground"> (manual)</span>
+									)}
+								</>
+							) : (
+								<span className="text-muted-foreground">Not scheduled</span>
+							)}
+						</p>
+					</div>
 					<div>
 						<p className="mb-2 text-sm font-medium">Actions</p>
 						<div className="flex w-full flex-row gap-2">
@@ -137,6 +179,32 @@ export function ServerStatusCard() {
 								tooltip="Restart server"
 							/>
 						</div>
+					</div>
+					<div className="space-y-2">
+						<p className="text-sm font-medium">Quick restart</p>
+						<div className="flex w-full flex-row gap-2">
+							{TEMP_PRESETS.map((m) => (
+								<Button
+									key={m}
+									size="sm"
+									variant="outline"
+									disabled={!canStop}
+									className="flex-1"
+									onClick={() => restartIn(m)}
+								>
+									+{m}m
+								</Button>
+							))}
+						</div>
+						<Button
+							size="sm"
+							variant="ghost"
+							className="w-full"
+							disabled={!hasUpcomingRestart}
+							onClick={() => skip()}
+						>
+							Cancel restart
+						</Button>
 					</div>
 					{serverState.version && (
 						<div className="space-y-3 border-t pt-3">

--- a/apps/webpanel/src/hooks/use-schedule.ts
+++ b/apps/webpanel/src/hooks/use-schedule.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useState } from 'react';
+import type {
+	ApiResponse,
+	RestartScheduleStatus,
+} from '@fxmanager/shared/types';
+import { QueryService } from '@/lib/query';
+import { toast } from 'sonner';
+
+const POLL_MS = 30_000;
+
+export function useSchedule() {
+	const [status, setStatus] = useState<RestartScheduleStatus | null>(null);
+
+	const refresh = useCallback(async () => {
+		try {
+			const res = await QueryService<ApiResponse<RestartScheduleStatus>>({
+				endpoint: '/server/schedule',
+				method: 'GET',
+			});
+			if (res.success) setStatus(res.data);
+		} catch {
+			// best-effort; the rest of the card still works without the countdown
+		}
+	}, []);
+
+	useEffect(() => {
+		void refresh();
+		const id = setInterval(() => void refresh(), POLL_MS);
+		return () => clearInterval(id);
+	}, [refresh]);
+
+	const restartIn = useCallback(
+		async (minutes: number) => {
+			try {
+				await QueryService({
+					endpoint: '/server/schedule/restart-in',
+					method: 'POST',
+					body: { minutes },
+				});
+				toast.success(
+					`Restart scheduled in ${minutes} minute${minutes === 1 ? '' : 's'}.`,
+				);
+				await refresh();
+			} catch {
+				toast.error('Failed to schedule restart.');
+			}
+		},
+		[refresh],
+	);
+
+	const skip = useCallback(async () => {
+		try {
+			const res = await QueryService<ApiResponse<{ skipped: boolean }>>({
+				endpoint: '/server/schedule/skip',
+				method: 'POST',
+			});
+			if (res.success && res.data.skipped) toast.success('Next restart cancelled.');
+			else toast.info('No upcoming restart to cancel.');
+			await refresh();
+		} catch {
+			toast.error('Failed to cancel restart.');
+		}
+	}, [refresh]);
+
+	return { status, refresh, restartIn, skip };
+}

--- a/apps/webpanel/src/pages/settings/index.tsx
+++ b/apps/webpanel/src/pages/settings/index.tsx
@@ -18,6 +18,7 @@ import GeneralTab from './tabs/general';
 import { useCallback, useEffect, useState } from 'react';
 import FXServerTab from './tabs/fxserver';
 import WhitelistTab from './tabs/whitelist';
+import RestartsTab from './tabs/restarts';
 import { QueryService } from '@/lib/query';
 import type {
 	ApiResponse,
@@ -56,6 +57,12 @@ const TABS = [
 		label: 'Whitelist',
 		description: 'Control who is allowed to join the server.',
 		component: WhitelistTab,
+	},
+	{
+		value: 'restarts',
+		label: 'Restarts',
+		description: 'Schedule automatic server restarts and warn players.',
+		component: RestartsTab,
 	},
 ] satisfies Tab[];
 

--- a/apps/webpanel/src/pages/settings/tabs/restarts.tsx
+++ b/apps/webpanel/src/pages/settings/tabs/restarts.tsx
@@ -1,0 +1,185 @@
+import { useCallback, useEffect, useState } from 'react';
+import type {
+	ApiResponse,
+	RestartScheduleStatus,
+} from '@fxmanager/shared/types';
+import { Button } from '@fxmanager/ui/components/button';
+import { Input } from '@fxmanager/ui/components/input';
+import { Label } from '@fxmanager/ui/components/label';
+import { Separator } from '@fxmanager/ui/components/separator';
+import { Switch } from '@fxmanager/ui/components/switch';
+import { toast } from 'sonner';
+import SettingRow from '../components/settingrow';
+import type { SettingsTabProps } from '@/types/settings';
+import { QueryService } from '@/lib/query';
+
+type TimeListProps = {
+	value: string[];
+	disabled?: boolean;
+	onSave: (value: string[]) => void;
+};
+
+function TimeListSetting({ value, disabled, onSave }: TimeListProps) {
+	const [draft, setDraft] = useState(value);
+
+	useEffect(() => {
+		setDraft(value);
+	}, [value]);
+
+	const addTime = () => setDraft((prev) => [...prev, '00:00']);
+	const updateTime = (index: number, next: string) =>
+		setDraft((prev) => prev.map((item, i) => (i === index ? next : item)));
+	const removeTime = (index: number) =>
+		setDraft((prev) => prev.filter((_, i) => i !== index));
+	const cancel = () => setDraft(value);
+	const save = () => onSave(draft.filter(Boolean));
+
+	const isDirty = JSON.stringify(draft) !== JSON.stringify(value);
+
+	return (
+		<div className="space-y-3 w-100">
+			<div className="flex gap-2">
+				<Button
+					type="button"
+					variant="outline"
+					disabled={disabled}
+					onClick={addTime}
+				>
+					Add time
+				</Button>
+
+				<Button type="button" disabled={disabled || !isDirty} onClick={save}>
+					Save
+				</Button>
+
+				<Button
+					type="button"
+					variant="ghost"
+					disabled={disabled || !isDirty}
+					onClick={cancel}
+				>
+					Cancel
+				</Button>
+			</div>
+
+			<div className="space-y-2">
+				{draft.map((time, index) => (
+					<div key={String(index)} className="flex gap-2">
+						<Input
+							type="time"
+							value={time}
+							disabled={disabled}
+							onChange={(event) => updateTime(index, event.currentTarget.value)}
+						/>
+
+						<Button
+							type="button"
+							variant="secondary"
+							disabled={disabled}
+							onClick={() => removeTime(index)}
+						>
+							Remove
+						</Button>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
+
+export default function RestartsTab({
+	data,
+	onChange,
+	disabled,
+}: SettingsTabProps<'restarts'>) {
+	const enabled = data['restarts.enabled'] === 'true';
+	const times = data['restarts.times']?.split(',').filter(Boolean) ?? [];
+
+	const [status, setStatus] = useState<RestartScheduleStatus | null>(null);
+	const [skipping, setSkipping] = useState(false);
+
+	const fetchStatus = useCallback(async () => {
+		try {
+			const res = await QueryService<ApiResponse<RestartScheduleStatus>>({
+				endpoint: '/server/schedule',
+				method: 'GET',
+			});
+			if (res.success) setStatus(res.data);
+		} catch {
+			// best-effort; the editor still works without live status
+		}
+	}, []);
+
+	useEffect(() => {
+		void fetchStatus();
+	}, [fetchStatus]);
+
+	async function skipNext() {
+		setSkipping(true);
+		try {
+			const res = await QueryService<
+				ApiResponse<{ skipped: boolean; nextRestart: string | null }>
+			>({ endpoint: '/server/schedule/skip', method: 'POST' });
+
+			if (res.success && res.data.skipped) {
+				toast.success('Next scheduled restart skipped.');
+			} else {
+				toast.info('No upcoming restart to skip.');
+			}
+
+			await fetchStatus();
+		} catch {
+			toast.error('Failed to skip restart.');
+		}
+		setSkipping(false);
+	}
+
+	const nextRestart = status?.nextRestart
+		? new Date(status.nextRestart).toLocaleString()
+		: '—';
+
+	return (
+		<div className="space-y-4">
+			<SettingRow label="Enable scheduled restarts">
+				<Switch
+					checked={enabled}
+					disabled={disabled}
+					onCheckedChange={(checked) =>
+						onChange('restarts.enabled', checked ? 'true' : 'false')
+					}
+				/>
+			</SettingRow>
+
+			<Separator />
+
+			<div className="flex flex-col gap-4">
+				<Label>Restart times (server local time)</Label>
+
+				<TimeListSetting
+					value={times}
+					disabled={disabled}
+					onSave={(next) => onChange('restarts.times', next.join(','))}
+				/>
+			</div>
+
+			<Separator />
+
+			<SettingRow label="Next restart">
+				<div className="flex items-center gap-3">
+					<span className="text-sm text-muted-foreground">
+						{status?.skipped ? `${nextRestart} (next skipped)` : nextRestart}
+					</span>
+
+					<Button
+						type="button"
+						variant="secondary"
+						disabled={disabled || skipping || !status?.nextRestart}
+						onClick={skipNext}
+					>
+						Skip next restart
+					</Button>
+				</div>
+			</SettingRow>
+		</div>
+	);
+}

--- a/packages/shared/src/constants/settings.ts
+++ b/packages/shared/src/constants/settings.ts
@@ -4,6 +4,7 @@ export const SETTINGS_SCOPES = {
 	general: [],
 	fxserver: ['onesync', 'executablePath', 'serverDataPath', 'serverConfigPath'],
 	whitelist: ['mode', 'discordBotToken', 'discordGuildId', 'discordRoleIds'],
+	restarts: ['enabled', 'times'],
 } as const;
 
 export const SETTINGS_KEYS = Object.fromEntries(
@@ -19,4 +20,6 @@ export const SETTINGS_DEFAULTS = {
 	'fxserver.serverDataPath': './server-data',
 	'fxserver.serverConfigPath': 'server.cfg',
 	'whitelist.mode': 'none',
+	'restarts.enabled': 'false',
+	'restarts.times': '',
 } satisfies Partial<Record<SettingsKey, string>>;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -7,6 +7,7 @@ export * from './process-manager';
 export * from './players';
 export * from './security';
 export * from './settings';
+export * from './txadmin';
 export * from './websockets';
 export * from './perf';
 export * from './whitelist';

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -36,3 +36,11 @@ export type SettingsKey<T extends SettingsScope = SettingsScope> = {
 export type SettingsKeysByScope = {
 	[Scope in SettingsScope]: SettingsKey<Scope>[];
 };
+
+export interface RestartScheduleStatus {
+	enabled: boolean;
+	times: string[];
+	nextRestart: string | null;
+	temporary: boolean;
+	skipped: boolean;
+}

--- a/packages/shared/src/types/txadmin.ts
+++ b/packages/shared/src/types/txadmin.ts
@@ -1,0 +1,111 @@
+// txAdmin compatibility events. Names and payload field names mirror txAdmin's
+// public event API (https://github.com/citizenfx/txAdmin, docs/events.md)
+
+export const TX_EVENT_PREFIX = 'txAdmin:events:';
+
+export const TX_EVENT_NAMES = [
+	// server
+	'announcement',
+	'serverShuttingDown',
+	'scheduledRestart',
+	'scheduledRestartSkipped',
+	// player
+	'playerBanned',
+	'playerDirectMessage',
+	'playerHealed',
+	'playerKicked',
+	'playerWarned',
+	// whitelist
+	'whitelistPlayer',
+	'whitelistPreApproval',
+	'whitelistRequest',
+	// other
+	'actionRevoked',
+	'adminAuth',
+	'adminsUpdated',
+	'configChanged',
+	'consoleCommand',
+] as const;
+
+export type TxEventName = (typeof TX_EVENT_NAMES)[number];
+
+export interface TxEventPayloads {
+	announcement: { author: string; message: string };
+	serverShuttingDown: { delay: number; author: string; message: string };
+	scheduledRestart: { secondsRemaining: number; translatedMessage: string };
+	scheduledRestartSkipped: {
+		secondsRemaining: number;
+		temporary: boolean;
+		author: string;
+	};
+
+	playerBanned: {
+		author: string;
+		reason: string;
+		actionId: string;
+		expiration: number | false;
+		durationInput: string;
+		durationTranslated: string | null;
+		targetNetId: number | null;
+		targetIds: string[];
+		targetHwids: string[];
+		targetName: string;
+		kickMessage: string;
+	};
+	playerDirectMessage: { target: number; author: string; message: string };
+	playerHealed: { target: number; author: string };
+	playerKicked: {
+		target: number;
+		author: string;
+		reason: string;
+		dropMessage: string;
+	};
+	playerWarned: {
+		author: string;
+		reason: string;
+		actionId: string;
+		targetNetId: number | null;
+		targetIds: string[];
+		targetName: string;
+	};
+
+	whitelistPlayer: {
+		action: 'added' | 'removed';
+		license: string;
+		playerName: string;
+		adminName: string;
+	};
+	whitelistPreApproval: {
+		action: 'added' | 'removed';
+		identifier: string;
+		playerName?: string;
+		adminName: string;
+	};
+	whitelistRequest: {
+		action: 'requested' | 'approved' | 'denied' | 'deniedAll';
+		playerName?: string;
+		requestId?: string;
+		license?: string;
+		adminName?: string;
+	};
+
+	actionRevoked: {
+		actionId: string;
+		actionType: string;
+		actionReason: string;
+		actionAuthor: string;
+		playerName: string | false;
+		playerIds: string[];
+		playerHwids: string[];
+		revokedBy: string;
+	};
+	adminAuth: { netid: number; isAdmin: boolean; username?: string };
+	adminsUpdated: number[];
+	configChanged: undefined;
+	consoleCommand: { author: string; channel: string; command: string };
+}
+
+export type TxEventEnvelope<E extends TxEventName = TxEventName> = {
+	event: E;
+	data: TxEventPayloads[E];
+};


### PR DESCRIPTION
## Description
A lot of stuff was missing such as:
- Restarting the server ended process immediately instead of waiting 10 seconds
- Missing txadmin support
- kicking/Banning players not working as intended
- schedule restart

have all been introduced here.

The are still some work left to do but this PR was getting a little too wide and I need to scope it in more on a few upcoming PRs tomorrow.

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [x] Builds & runs on Windows
- [x] Builds & runs on Linux

---

## Additional Notes
N/A
