### PR TITLE
feat: console improvements

### DIFF
--- a/apps/core/src/modules/process/manager.test.ts
+++ b/apps/core/src/modules/process/manager.test.ts
@@ -511,8 +511,57 @@ describe('ProcessManager', () => {
 				}),
 			);
 			expect(broadcastSpy).toHaveBeenCalledWith(
-				expect.objectContaining({ channel: 'console', event: 'line' }),
+				expect.objectContaining({
+					channel: 'console',
+					event: 'lines',
+					data: expect.arrayContaining([
+						expect.objectContaining({
+							line: expect.stringContaining('Dynamic Trace Event'),
+						}),
+					]),
+				}),
 			);
+		});
+	});
+
+	describe('Console output batching', () => {
+		// Stray flush timers from other tests' manager instances can fire mid-test,
+		// so assertions filter broadcasts down to this test's own marked lines
+		const batchesWithMarker = (marker: string) =>
+			broadcastSpy.mock.calls
+				.map((call) => call[0] as any)
+				.filter(
+					(msg) =>
+						msg.channel === 'console' &&
+						msg.event === 'lines' &&
+						msg.data.some((l: any) => l.line.includes(marker)),
+				);
+
+		it('broadcasts the first line immediately and coalesces the rest of the burst into one batch', async () => {
+			processManager.injectConsoleLine({ value: 'burst-one', noPrint: true });
+			processManager.injectConsoleLine({ value: 'burst-two', noPrint: true });
+			processManager.injectConsoleLine({ value: 'burst-three', noPrint: true });
+
+			expect(batchesWithMarker('burst-')).toHaveLength(1);
+			expect(batchesWithMarker('burst-')[0].data).toHaveLength(1);
+
+			await Bun.sleep(70);
+
+			const batches = batchesWithMarker('burst-');
+			expect(batches).toHaveLength(2);
+			expect(batches[1].data).toHaveLength(2);
+		});
+
+		it('stamps strictly increasing seq values on every emitted line', async () => {
+			processManager.injectConsoleLine({ value: 'seq-a', noPrint: true });
+			processManager.injectConsoleLine({ value: 'seq-b', noPrint: true });
+			processManager.injectConsoleLine({ value: 'seq-c', noPrint: true });
+			await Bun.sleep(70);
+
+			const seqs = batchesWithMarker('seq-')
+				.flatMap((msg) => msg.data)
+				.map((line: any) => line.seq);
+			expect(seqs).toEqual([0, 1, 2]);
 		});
 	});
 });

--- a/apps/core/src/modules/process/manager.test.ts
+++ b/apps/core/src/modules/process/manager.test.ts
@@ -526,8 +526,7 @@ describe('ProcessManager', () => {
 	});
 
 	describe('Console output batching', () => {
-		// Stray flush timers from other tests' manager instances can fire mid-test,
-		// so assertions filter broadcasts down to this test's own marked lines
+		// stray flush timers from other tests' instances can fire mid-test
 		const batchesWithMarker = (marker: string) =>
 			broadcastSpy.mock.calls
 				.map((call) => call[0] as any)

--- a/apps/core/src/modules/process/manager.test.ts
+++ b/apps/core/src/modules/process/manager.test.ts
@@ -508,6 +508,7 @@ describe('ProcessManager', () => {
 				expect.objectContaining({
 					line: expect.stringContaining('Dynamic Trace Event'),
 					source: 'stdout',
+					seq: expect.any(Number),
 				}),
 			);
 			expect(broadcastSpy).toHaveBeenCalledWith(
@@ -545,7 +546,7 @@ describe('ProcessManager', () => {
 			expect(batchesWithMarker('burst-')).toHaveLength(1);
 			expect(batchesWithMarker('burst-')[0].data).toHaveLength(1);
 
-			await Bun.sleep(70);
+			await Bun.sleep(100);
 
 			const batches = batchesWithMarker('burst-');
 			expect(batches).toHaveLength(2);
@@ -556,7 +557,7 @@ describe('ProcessManager', () => {
 			processManager.injectConsoleLine({ value: 'seq-a', noPrint: true });
 			processManager.injectConsoleLine({ value: 'seq-b', noPrint: true });
 			processManager.injectConsoleLine({ value: 'seq-c', noPrint: true });
-			await Bun.sleep(70);
+			await Bun.sleep(100);
 
 			const seqs = batchesWithMarker('seq-')
 				.flatMap((msg) => msg.data)

--- a/apps/core/src/modules/process/manager.ts
+++ b/apps/core/src/modules/process/manager.ts
@@ -15,8 +15,10 @@ import { txAdminCompat } from '../txadmin/compat';
 const STARTUP_STALL_MS = 90_000;
 const KILL_GRACE_MS = 5_000;
 const SHUTDOWN_EVENT_GRACE_MS = 10_000;
+const CONSOLE_FLUSH_MS = 50;
 
 type ShutdownOpts = { author?: string; message?: string };
+type RawOutputLine = Omit<ProcessOutputLine, 'seq'>;
 
 export class ProcessManager {
 	private state: ServerState = {
@@ -28,6 +30,9 @@ export class ProcessManager {
 	private buffer = new LogBuffer<ProcessOutputLine>();
 	private config = ConfigManager.getInstance();
 	private startupTimer: ReturnType<typeof setTimeout> | null = null;
+	private lineSeq = 0;
+	private pendingLines: ProcessOutputLine[] = [];
+	private flushTimer: ReturnType<typeof setTimeout> | null = null;
 	private readonly startupStallMs: number;
 	private readonly shutdownGraceMs: number;
 
@@ -76,7 +81,7 @@ export class ProcessManager {
 					'\x1b[1m\x1b[32m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1b[0m\n\n',
 				ts: Date.now(),
 				source: 'stdout',
-			} satisfies ProcessOutputLine,
+			} satisfies RawOutputLine,
 		});
 
 		try {
@@ -134,7 +139,7 @@ export class ProcessManager {
 					'\x1b[1m\x1b[31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1b[0m\n\n',
 				ts: Date.now(),
 				source: 'stdout',
-			} satisfies ProcessOutputLine,
+			} satisfies RawOutputLine,
 		});
 
 		if (wasRunning) await this.announceShutdown(opts);
@@ -152,7 +157,7 @@ export class ProcessManager {
 					'\x1b[2m\x1b[37m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1b[0m\n\n',
 				ts: Date.now(),
 				source: 'stdout',
-			} satisfies ProcessOutputLine,
+			} satisfies RawOutputLine,
 		});
 
 		return true;
@@ -200,7 +205,7 @@ export class ProcessManager {
 	}
 
 	injectConsoleLine(params: {
-		payload?: ProcessOutputLine;
+		payload?: RawOutputLine;
 		process?: string;
 		value?: string;
 		color?: string;
@@ -230,18 +235,40 @@ export class ProcessManager {
 				line: `${ansiColor}[${paddedProcess}] ${value}\x1b[0m`,
 				ts: Date.now(),
 				source: 'stdout',
-			} satisfies ProcessOutputLine;
+			} satisfies RawOutputLine;
 		}
 
 		if (!noPrint) {
 			console.log(payload.line);
 		}
 
-		this.buffer.push(payload);
+		this.emitLine(payload);
+	}
+
+	private emitLine(raw: RawOutputLine) {
+		const line = { ...raw, seq: this.lineSeq++ } satisfies ProcessOutputLine;
+		this.buffer.push(line);
+		this.pendingLines.push(line);
+		this.scheduleFlush();
+	}
+
+	private scheduleFlush() {
+		if (this.flushTimer) return;
+		this.flushLines();
+		this.flushTimer = setTimeout(() => {
+			this.flushTimer = null;
+			if (this.pendingLines.length > 0) this.scheduleFlush();
+		}, CONSOLE_FLUSH_MS);
+	}
+
+	private flushLines() {
+		if (this.pendingLines.length === 0) return;
+		const batch = this.pendingLines;
+		this.pendingLines = [];
 		wsManager.broadcast({
 			channel: 'console',
-			event: 'line',
-			data: payload,
+			event: 'lines',
+			data: batch,
 		});
 	}
 
@@ -410,7 +437,7 @@ export class ProcessManager {
 					line: value,
 					source,
 					ts: Date.now(),
-				} satisfies ProcessOutputLine;
+				} satisfies RawOutputLine;
 
 				if (this.state.status === 'starting') {
 					if (value.includes('Authenticated with cfx.re Nucleus')) {
@@ -423,12 +450,7 @@ export class ProcessManager {
 
 				console.log(value);
 
-				this.buffer.push(event);
-				wsManager.broadcast({
-					channel: 'console',
-					event: 'line',
-					data: event,
-				});
+				this.emitLine(event);
 			}
 		} catch (err) {
 			console.error(`Stream error:`, err);

--- a/apps/core/src/modules/process/manager.ts
+++ b/apps/core/src/modules/process/manager.ts
@@ -259,6 +259,7 @@ export class ProcessManager {
 			this.flushTimer = null;
 			if (this.pendingLines.length > 0) this.scheduleFlush();
 		}, CONSOLE_FLUSH_MS);
+		this.flushTimer.unref?.();
 	}
 
 	private flushLines() {

--- a/apps/resource/src/server/httphandler/class.ts
+++ b/apps/resource/src/server/httphandler/class.ts
@@ -191,7 +191,6 @@ export class HttpServer {
 
 		try {
 			const response = await route.handler(req);
-			console.log('resposne to request:', response);
 			this.sendResponse(rawRes, response);
 		} catch (err) {
 			console.error(

--- a/apps/resource/src/server/httphandler/index.ts
+++ b/apps/resource/src/server/httphandler/index.ts
@@ -27,7 +27,6 @@ api.post(
 );
 
 api.get('/resources/load', () => {
-	console.log('Received request on /resources/load');
 	return {
 		status: 200,
 		body: { success: true, data: getResourcesData() },

--- a/apps/webpanel/src/context/WsContext.tsx
+++ b/apps/webpanel/src/context/WsContext.tsx
@@ -20,7 +20,7 @@ export function WSProvider({ children }: { children: ReactNode }) {
 	const socketRef = useRef<WebSocket | null>(null);
 	// handlers keyed by `channel:event`
 	const handlersRef = useRef<Map<string, Set<MessageHandler>>>(new Map());
-	// refcounted active subscriptions, replayed after every (re)connect
+	// refcounted subscriptions, replayed on reconnect
 	const subsRef = useRef<Map<Channel, number>>(new Map());
 
 	useEffect(() => {
@@ -37,8 +37,6 @@ export function WSProvider({ children }: { children: ReactNode }) {
 			ws.onopen = () => {
 				retryDelay = RECONNECT_MIN_MS;
 				setConnected(true);
-				// Resubscribe active channels; the server answers each with a
-				// fresh 'initial' dump, restoring state lost while disconnected
 				for (const channel of subsRef.current.keys()) {
 					ws.send(JSON.stringify({ type: 'subscribe', channel }));
 				}
@@ -85,8 +83,6 @@ export function WSProvider({ children }: { children: ReactNode }) {
 		(channel: Channel) => {
 			const count = subsRef.current.get(channel) ?? 0;
 			subsRef.current.set(channel, count + 1);
-			// Always forward: the server re-sends 'initial', so late co-subscribers
-			// still get their state. No-op while disconnected (replayed on open).
 			send({ type: 'subscribe', channel });
 		},
 		[send],

--- a/apps/webpanel/src/context/WsContext.tsx
+++ b/apps/webpanel/src/context/WsContext.tsx
@@ -11,52 +11,64 @@ import {
 	type ReactNode,
 } from 'react';
 
+const RECONNECT_MIN_MS = 500;
+const RECONNECT_MAX_MS = 10_000;
+
 export function WSProvider({ children }: { children: ReactNode }) {
 	const { user } = useAuth();
 	const [connected, setConnected] = useState(false);
 	const socketRef = useRef<WebSocket | null>(null);
 	// handlers keyed by `channel:event`
 	const handlersRef = useRef<Map<string, Set<MessageHandler>>>(new Map());
-	const pendingRef = useRef<Set<Channel>>(new Set()); // subscriptions before connect
+	// refcounted active subscriptions, replayed after every (re)connect
+	const subsRef = useRef<Map<Channel, number>>(new Map());
 
 	useEffect(() => {
-		if (!user) {
-			if (socketRef.current) {
-				socketRef.current.close();
-				socketRef.current = null;
+		if (!user) return;
+
+		let disposed = false;
+		let retryDelay = RECONNECT_MIN_MS;
+		let retryTimer: ReturnType<typeof setTimeout> | undefined;
+
+		const connect = () => {
+			const ws = new WebSocket(WSUrl());
+			socketRef.current = ws;
+
+			ws.onopen = () => {
+				retryDelay = RECONNECT_MIN_MS;
+				setConnected(true);
+				// Resubscribe active channels; the server answers each with a
+				// fresh 'initial' dump, restoring state lost while disconnected
+				for (const channel of subsRef.current.keys()) {
+					ws.send(JSON.stringify({ type: 'subscribe', channel }));
+				}
+			};
+
+			ws.onclose = () => {
+				// A stale socket's close can arrive after a newer one took over
+				if (socketRef.current === ws) socketRef.current = null;
+				if (disposed) return;
 				setConnected(false);
-			}
+				retryTimer = setTimeout(connect, retryDelay);
+				retryDelay = Math.min(retryDelay * 2, RECONNECT_MAX_MS);
+			};
 
-			return;
-		}
-
-		if (socketRef.current) return;
-
-		const ws = new WebSocket(WSUrl());
-		socketRef.current = ws;
-
-		ws.onopen = () => {
-			setConnected(true);
-			// Flush subscriptions that were registered before the socket connected
-			for (const channel of pendingRef.current) {
-				ws.send(JSON.stringify({ type: 'subscribe', channel }));
-			}
-			pendingRef.current.clear();
+			ws.onmessage = (event) => {
+				try {
+					const msg: WSMessage = JSON.parse(event.data);
+					const key = `${msg.channel}:${msg.event}`;
+					handlersRef.current.get(key)?.forEach((h) => {
+						h(msg);
+					});
+				} catch {}
+			};
 		};
 
-		ws.onclose = () => setConnected(false);
-
-		ws.onmessage = (event) => {
-			try {
-				const msg: WSMessage = JSON.parse(event.data);
-				const key = `${msg.channel}:${msg.event}`;
-				handlersRef.current.get(key)?.forEach((h) => {
-					h(msg);
-				});
-			} catch {}
-		};
+		connect();
 
 		return () => {
+			disposed = true;
+			clearTimeout(retryTimer);
 			socketRef.current?.close();
 			socketRef.current = null;
 			setConnected(false);
@@ -71,19 +83,24 @@ export function WSProvider({ children }: { children: ReactNode }) {
 
 	const subscribe = useCallback(
 		(channel: Channel) => {
-			if (socketRef.current?.readyState === WebSocket.OPEN) {
-				send({ type: 'subscribe', channel });
-			} else {
-				pendingRef.current.add(channel);
-			}
+			const count = subsRef.current.get(channel) ?? 0;
+			subsRef.current.set(channel, count + 1);
+			// Always forward: the server re-sends 'initial', so late co-subscribers
+			// still get their state. No-op while disconnected (replayed on open).
+			send({ type: 'subscribe', channel });
 		},
 		[send],
 	);
 
 	const unsubscribe = useCallback(
 		(channel: Channel) => {
-			pendingRef.current.delete(channel);
-			send({ type: 'unsubscribe', channel });
+			const count = subsRef.current.get(channel) ?? 0;
+			if (count <= 1) {
+				subsRef.current.delete(channel);
+				send({ type: 'unsubscribe', channel });
+			} else {
+				subsRef.current.set(channel, count - 1);
+			}
 		},
 		[send],
 	);

--- a/apps/webpanel/src/hooks/ws-channels/use-console.ts
+++ b/apps/webpanel/src/hooks/ws-channels/use-console.ts
@@ -4,8 +4,6 @@ import type { ProcessOutputLine } from '@fxmanager/shared/types';
 
 interface UseConsoleOptions {
 	maxLines?: number;
-	// While true, appended lines aren't trimmed from the top so a scrolled-up
-	// reading position stays stable; bounded by TRIM_OVERSHOOT
 	suspendTrim?: boolean;
 }
 
@@ -50,7 +48,6 @@ export function useConsoleSocket({
 			},
 		);
 
-		// Batched delivery; seq filter drops lines already covered by the initial dump
 		const offLines = on<ProcessOutputLine[]>('console', 'lines', ({ data }) => {
 			setLines((prev) => {
 				const lastSeq = prev.length > 0 ? prev[prev.length - 1].seq : -1;

--- a/apps/webpanel/src/hooks/ws-channels/use-console.ts
+++ b/apps/webpanel/src/hooks/ws-channels/use-console.ts
@@ -4,7 +4,12 @@ import type { ProcessOutputLine } from '@fxmanager/shared/types';
 
 interface UseConsoleOptions {
 	maxLines?: number;
+	// While true, appended lines aren't trimmed from the top so a scrolled-up
+	// reading position stays stable; bounded by TRIM_OVERSHOOT
+	suspendTrim?: boolean;
 }
+
+const TRIM_OVERSHOOT = 1000;
 
 interface UseConsoleReturn {
 	lines: ProcessOutputLine[];
@@ -14,11 +19,17 @@ interface UseConsoleReturn {
 
 export function useConsoleSocket({
 	maxLines = 500,
+	suspendTrim = false,
 }: UseConsoleOptions = {}): UseConsoleReturn {
 	const { subscribe, unsubscribe, on, emit } = useWSBase();
 	const [lines, setLines] = useState<ProcessOutputLine[]>([]);
 	// Persist lines across re-mounts (page navigation) via a ref-backed cache
 	const cache = useRef<ProcessOutputLine[]>([]);
+	const suspendTrimRef = useRef(suspendTrim);
+
+	useEffect(() => {
+		suspendTrimRef.current = suspendTrim;
+	}, [suspendTrim]);
 
 	useEffect(() => {
 		// Restore cached lines on mount so navigating away and back doesn't lose history
@@ -26,7 +37,7 @@ export function useConsoleSocket({
 
 		subscribe('console');
 
-		// Server dumps last N lines on subscribe via a 'history' event
+		// Server dumps last N lines on subscribe via an 'initial' event
 		const offInitial = on<ProcessOutputLine[]>(
 			'console',
 			'initial',
@@ -45,7 +56,10 @@ export function useConsoleSocket({
 				const lastSeq = prev.length > 0 ? prev[prev.length - 1].seq : -1;
 				const fresh = data.filter((l) => l.seq > lastSeq);
 				if (fresh.length === 0) return prev;
-				const next = [...prev, ...fresh].slice(-maxLines);
+				const cap = suspendTrimRef.current
+					? maxLines + TRIM_OVERSHOOT
+					: maxLines;
+				const next = [...prev, ...fresh].slice(-cap);
 				cache.current = next;
 				return next;
 			});

--- a/apps/webpanel/src/hooks/ws-channels/use-console.ts
+++ b/apps/webpanel/src/hooks/ws-channels/use-console.ts
@@ -39,16 +39,20 @@ export function useConsoleSocket({
 			},
 		);
 
-		const offLine = on<ProcessOutputLine>('console', 'line', ({ data }) => {
+		// Batched delivery; seq filter drops lines already covered by the initial dump
+		const offLines = on<ProcessOutputLine[]>('console', 'lines', ({ data }) => {
 			setLines((prev) => {
-				const next = [...prev, data].slice(-maxLines);
+				const lastSeq = prev.length > 0 ? prev[prev.length - 1].seq : -1;
+				const fresh = data.filter((l) => l.seq > lastSeq);
+				if (fresh.length === 0) return prev;
+				const next = [...prev, ...fresh].slice(-maxLines);
 				cache.current = next;
 				return next;
 			});
 		});
 
 		return () => {
-			offLine();
+			offLines();
 			offInitial();
 			unsubscribe('console');
 		};

--- a/apps/webpanel/src/pages/console/index.tsx
+++ b/apps/webpanel/src/pages/console/index.tsx
@@ -51,7 +51,6 @@ const LogLine = memo(function LogLine({ event }: { event: ProcessOutputLine }) {
 export default function Console() {
 	const [maxLines, setMaxLines] = useState<number>(200);
 	const [following, setFollowing] = useState<boolean>(true);
-	// Pausing suspends top-trimming so the buffer can't shift under the reader
 	const { lines, sendCommand, clear } = useConsoleSocket({
 		maxLines,
 		suspendTrim: !following,
@@ -138,8 +137,6 @@ export default function Console() {
 		el.scrollTop = el.scrollHeight;
 	}, [visibleLines]);
 
-	// Following is derived from where the user scrolls: leaving the bottom
-	// pauses it (recording the seq for the new-lines badge), returning resumes
 	useEffect(() => {
 		const el = viewportRef.current;
 		if (!el) return;

--- a/apps/webpanel/src/pages/console/index.tsx
+++ b/apps/webpanel/src/pages/console/index.tsx
@@ -15,9 +15,12 @@ import {
 	SelectValue,
 } from '@fxmanager/ui/components/select';
 import Ansi from 'ansi-to-react';
-import { ArrowRight, SendHorizonal, Terminal } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { ArrowRight, Filter, SendHorizonal, Terminal, X } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import './styles.css';
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: strips ANSI color codes for filter matching
+const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
 
 function LogLine({ event }: { event: ProcessOutputLine }) {
 	return (
@@ -31,7 +34,7 @@ function LogLine({ event }: { event: ProcessOutputLine }) {
 
 export default function Console() {
 	const [maxLines, setMaxLines] = useState<number>(200);
-	const { lines, sendCommand } = useConsoleSocket({ maxLines });
+	const { lines, sendCommand, clear } = useConsoleSocket({ maxLines });
 	const {
 		state: { status: serverStatus },
 	} = useServerStateSocket();
@@ -41,14 +44,31 @@ export default function Console() {
 	const [input, setInput] = useState<string>('');
 	const [history, setHistory] = useState<string[]>([]);
 	const [histIdx, setHistIdx] = useState<number>(-1);
+	const [filterOpen, setFilterOpen] = useState<boolean>(false);
+	const [filter, setFilter] = useState<string>('');
+
+	const visibleLines = useMemo(() => {
+		const query = filter.trim().toLowerCase();
+		if (!query) return lines;
+		return lines.filter((log) =>
+			log.line.replace(ANSI_PATTERN, '').toLowerCase().includes(query),
+		);
+	}, [lines, filter]);
+
+	const toggleFilter = () => {
+		if (filterOpen) setFilter('');
+		setFilterOpen(!filterOpen);
+	};
 
 	const submit = () => {
 		const cmd = input.trim();
 		if (!cmd) return;
-		sendCommand(cmd);
 		setHistory((h) => [cmd, ...h].slice(0, 50));
 		setHistIdx(-1);
 		setInput('');
+
+		if (cmd === 'clear' || cmd === 'cls') return clear();
+		sendCommand(cmd);
 
 		const el = viewportRef.current;
 		if (!el) return;
@@ -69,35 +89,55 @@ export default function Console() {
 		}
 	};
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: visibleLines re-triggers the scroll on new output
 	useEffect(() => {
 		const el = viewportRef.current;
-		if (!el) return;
-
-		if (autoScroll === true) {
-			el.scrollTop = el.scrollHeight;
-			return;
-		}
-
-		const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
-		if (isNearBottom) {
-			el.scrollTop = el.scrollHeight;
-		}
-	}, [autoScroll]);
+		if (!el || autoScroll !== true) return;
+		el.scrollTop = el.scrollHeight;
+	}, [visibleLines, autoScroll]);
 
 	return (
 		<div className="flex h-full flex-col gap-4">
 			<PageHeader Icon={Terminal} title="Console" />
 
 			<Card className="flex flex-1 flex-col min-h-0 pb-0 overflow-hidden gap-0.5">
+				{filterOpen && (
+					<div className="flex flex-none items-center gap-2 border-b px-3 pb-2">
+						<Filter className="h-4 w-4 text-muted-foreground" />
+						<Input
+							value={filter}
+							onChange={(e) => setFilter(e.target.value)}
+							placeholder="Filter output..."
+							className="flex-1 border-0 bg-transparent font-mono text-sm shadow-none outline-none focus-visible:ring-0"
+						/>
+						{filter.trim() && (
+							<span className="text-xs text-muted-foreground whitespace-nowrap">
+								{visibleLines.length}/{lines.length}
+							</span>
+						)}
+						<Button
+							size="icon"
+							variant="ghost"
+							onClick={toggleFilter}
+							className="h-7 w-7 text-muted-foreground"
+						>
+							<X className="h-4 w-4" />
+						</Button>
+					</div>
+				)}
 				<ScrollArea className="flex-1 min-h-0" viewportRef={viewportRef}>
 					<div className="p-4 font-mono text-xs leading-relaxed">
 						{lines.length === 0 ? (
 							<p className="text-muted-foreground text-center py-4">
 								No output yet. Start the server to see logs.
 							</p>
+						) : visibleLines.length === 0 ? (
+							<p className="text-muted-foreground text-center py-4">
+								No lines match the filter.
+							</p>
 						) : (
 							<div className="flex flex-col">
-								{lines.map((log, i) => (
+								{visibleLines.map((log, i) => (
 									// biome-ignore lint/suspicious/noArrayIndexKey: line indexes are immutable ?
 									<LogLine event={log} key={i} />
 								))}
@@ -125,6 +165,16 @@ export default function Console() {
 					</div>
 
 					<div className="flex items-center gap-4 border-l pl-4 h-6 border-muted">
+						<Button
+							size="icon"
+							variant="ghost"
+							onClick={toggleFilter}
+							className={`h-7 w-7 ${
+								filterOpen ? 'text-primary' : 'text-muted-foreground'
+							}`}
+						>
+							<Filter className="h-4 w-4" />
+						</Button>
 						<div className="hidden sm:flex items-center gap-2 text-xs text-muted-foreground">
 							<span className="whitespace-nowrap">Max lines:</span>
 							<Select

--- a/apps/webpanel/src/pages/console/index.tsx
+++ b/apps/webpanel/src/pages/console/index.tsx
@@ -1,11 +1,10 @@
 import { PageHeader } from '@/components/page-header';
 import { useConsoleSocket, useServerStateSocket } from '@/hooks/ws-channels';
+import { useWSBase } from '@/hooks/ws-channels/use-ws-core';
 import type { ProcessOutputLine } from '@fxmanager/shared/types';
 import { Button } from '@fxmanager/ui/components/button';
 import { Card } from '@fxmanager/ui/components/card';
 import { Input } from '@fxmanager/ui/components/input';
-import { Checkbox } from '@fxmanager/ui/components/checkbox';
-import { Label } from '@fxmanager/ui/components/label';
 import { ScrollArea, ScrollBar } from '@fxmanager/ui/components/scroll-area';
 import {
 	Select,
@@ -15,14 +14,31 @@ import {
 	SelectValue,
 } from '@fxmanager/ui/components/select';
 import Ansi from 'ansi-to-react';
-import { ArrowRight, Filter, SendHorizonal, Terminal, X } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+	ArrowDown,
+	ArrowRight,
+	Filter,
+	LoaderCircle,
+	SendHorizonal,
+	Terminal,
+	X,
+} from 'lucide-react';
+import {
+	memo,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import './styles.css';
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: strips ANSI color codes for filter matching
 const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
 
-function LogLine({ event }: { event: ProcessOutputLine }) {
+const FOLLOW_THRESHOLD_PX = 40;
+
+const LogLine = memo(function LogLine({ event }: { event: ProcessOutputLine }) {
 	return (
 		<div className="font-mono text-sm leading-tight whitespace-pre-wrap">
 			<Ansi linkify className="ansi-item">
@@ -30,7 +46,7 @@ function LogLine({ event }: { event: ProcessOutputLine }) {
 			</Ansi>
 		</div>
 	);
-}
+});
 
 export default function Console() {
 	const [maxLines, setMaxLines] = useState<number>(200);
@@ -39,8 +55,13 @@ export default function Console() {
 		state: { status: serverStatus },
 	} = useServerStateSocket();
 
+	const { connected } = useWSBase();
+
 	const viewportRef = useRef<HTMLDivElement>(null);
-	const [autoScroll, setAutoScroll] = useState<boolean | 'indeterminate'>(true);
+	const [following, setFollowing] = useState<boolean>(true);
+	const followingRef = useRef(true);
+	const lastSeqRef = useRef(-1);
+	const pausedSeqRef = useRef(-1);
 	const [input, setInput] = useState<string>('');
 	const [history, setHistory] = useState<string[]>([]);
 	const [histIdx, setHistIdx] = useState<number>(-1);
@@ -54,6 +75,19 @@ export default function Console() {
 			log.line.replace(ANSI_PATTERN, '').toLowerCase().includes(query),
 		);
 	}, [lines, filter]);
+
+	lastSeqRef.current = lines.length > 0 ? lines[lines.length - 1].seq : -1;
+
+	const newCount = following
+		? 0
+		: visibleLines.filter((l) => l.seq > pausedSeqRef.current).length;
+
+	const jumpToBottom = () => {
+		followingRef.current = true;
+		setFollowing(true);
+		const el = viewportRef.current;
+		if (el) el.scrollTop = el.scrollHeight;
+	};
 
 	const toggleFilter = () => {
 		if (filterOpen) setFilter('');
@@ -69,10 +103,7 @@ export default function Console() {
 
 		if (cmd === 'clear' || cmd === 'cls') return clear();
 		sendCommand(cmd);
-
-		const el = viewportRef.current;
-		if (!el) return;
-		el.scrollTop = el.scrollHeight;
+		jumpToBottom();
 	};
 
 	const onKeyDown = (e: React.KeyboardEvent) => {
@@ -89,18 +120,44 @@ export default function Console() {
 		}
 	};
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: visibleLines re-triggers the scroll on new output
+	// biome-ignore lint/correctness/useExhaustiveDependencies: re-pins the scroll whenever rendered output changes
+	useLayoutEffect(() => {
+		const el = viewportRef.current;
+		if (!el || !followingRef.current) return;
+		el.scrollTop = el.scrollHeight;
+	}, [visibleLines]);
+
+	// Following is derived from where the user scrolls: leaving the bottom
+	// pauses it (recording the seq for the new-lines badge), returning resumes
 	useEffect(() => {
 		const el = viewportRef.current;
-		if (!el || autoScroll !== true) return;
-		el.scrollTop = el.scrollHeight;
-	}, [visibleLines, autoScroll]);
+		if (!el) return;
+
+		const onScroll = () => {
+			const nearBottom =
+				el.scrollHeight - el.scrollTop - el.clientHeight < FOLLOW_THRESHOLD_PX;
+			if (followingRef.current && !nearBottom) {
+				pausedSeqRef.current = lastSeqRef.current;
+			}
+			followingRef.current = nearBottom;
+			setFollowing(nearBottom);
+		};
+
+		el.addEventListener('scroll', onScroll);
+		return () => el.removeEventListener('scroll', onScroll);
+	}, []);
 
 	return (
 		<div className="flex h-full flex-col gap-4">
 			<PageHeader Icon={Terminal} title="Console" />
 
 			<Card className="flex flex-1 flex-col min-h-0 pb-0 overflow-hidden gap-0.5">
+				{!connected && (
+					<div className="flex flex-none items-center gap-2 border-b border-amber-500/20 bg-amber-500/10 px-3 pb-2 text-xs text-amber-500">
+						<LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+						<span>Connection lost — reconnecting...</span>
+					</div>
+				)}
 				{filterOpen && (
 					<div className="flex flex-none items-center gap-2 border-b px-3 pb-2">
 						<Filter className="h-4 w-4 text-muted-foreground" />
@@ -125,27 +182,41 @@ export default function Console() {
 						</Button>
 					</div>
 				)}
-				<ScrollArea className="flex-1 min-h-0" viewportRef={viewportRef}>
-					<div className="p-4 font-mono text-xs leading-relaxed">
-						{lines.length === 0 ? (
-							<p className="text-muted-foreground text-center py-4">
-								No output yet. Start the server to see logs.
-							</p>
-						) : visibleLines.length === 0 ? (
-							<p className="text-muted-foreground text-center py-4">
-								No lines match the filter.
-							</p>
-						) : (
-							<div className="flex flex-col">
-								{visibleLines.map((log, i) => (
-									// biome-ignore lint/suspicious/noArrayIndexKey: line indexes are immutable ?
-									<LogLine event={log} key={i} />
-								))}
-							</div>
-						)}
-					</div>
-					<ScrollBar orientation="horizontal" />
-				</ScrollArea>
+				<div className="relative flex-1 min-h-0">
+					<ScrollArea className="h-full" viewportRef={viewportRef}>
+						<div className="p-4 font-mono text-xs leading-relaxed">
+							{lines.length === 0 ? (
+								<p className="text-muted-foreground text-center py-4">
+									No output yet. Start the server to see logs.
+								</p>
+							) : visibleLines.length === 0 ? (
+								<p className="text-muted-foreground text-center py-4">
+									No lines match the filter.
+								</p>
+							) : (
+								<div className="flex flex-col">
+									{visibleLines.map((log) => (
+										<LogLine event={log} key={log.seq} />
+									))}
+								</div>
+							)}
+						</div>
+						<ScrollBar orientation="horizontal" />
+					</ScrollArea>
+					{!following && lines.length > 0 && (
+						<Button
+							size="sm"
+							variant="secondary"
+							onClick={jumpToBottom}
+							className="absolute bottom-3 left-1/2 -translate-x-1/2 z-10 h-7 gap-1.5 rounded-full border px-3 text-xs shadow-md"
+						>
+							<ArrowDown className="h-3.5 w-3.5" />
+							{newCount > 0
+								? `${newCount} new line${newCount === 1 ? '' : 's'}`
+								: 'Jump to bottom'}
+						</Button>
+					)}
+				</div>
 
 				<div className="flex flex-none items-center gap-4 border-t p-3 bg-background/50">
 					<div className="flex flex-1 items-center gap-2">
@@ -154,11 +225,13 @@ export default function Console() {
 							value={input}
 							onChange={(e) => setInput(e.target.value)}
 							onKeyDown={onKeyDown}
-							disabled={serverStatus !== 'running'}
+							disabled={serverStatus !== 'running' || !connected}
 							placeholder={
-								serverStatus === 'running'
-									? 'Enter server command...'
-									: 'Server not running...'
+								!connected
+									? 'Reconnecting...'
+									: serverStatus === 'running'
+										? 'Enter server command...'
+										: 'Server not running...'
 							}
 							className="flex-1 border-0 bg-transparent font-mono text-sm shadow-none outline-none focus-visible:ring-0"
 						/>
@@ -193,21 +266,13 @@ export default function Console() {
 							</Select>
 						</div>
 
-						<Label className="hidden md:flex items-center gap-2 text-xs text-muted-foreground cursor-pointer select-none">
-							<Checkbox
-								defaultChecked
-								checked={autoScroll}
-								onCheckedChange={setAutoScroll}
-							/>
-							<span>Auto-scroll</span>
-						</Label>
 					</div>
 
 					<Button
 						size="icon"
 						variant="ghost"
 						onClick={submit}
-						disabled={serverStatus !== 'running'}
+						disabled={serverStatus !== 'running' || !connected}
 						className="h-8 w-8 text-primary"
 					>
 						<SendHorizonal className="h-4 w-4" />

--- a/apps/webpanel/src/pages/console/index.tsx
+++ b/apps/webpanel/src/pages/console/index.tsx
@@ -50,15 +50,20 @@ const LogLine = memo(function LogLine({ event }: { event: ProcessOutputLine }) {
 
 export default function Console() {
 	const [maxLines, setMaxLines] = useState<number>(200);
-	const { lines, sendCommand, clear } = useConsoleSocket({ maxLines });
+	const [following, setFollowing] = useState<boolean>(true);
+	// Pausing suspends top-trimming so the buffer can't shift under the reader
+	const { lines, sendCommand, clear } = useConsoleSocket({
+		maxLines,
+		suspendTrim: !following,
+	});
 	const {
 		state: { status: serverStatus },
 	} = useServerStateSocket();
 
 	const { connected } = useWSBase();
+	const [everConnected, setEverConnected] = useState<boolean>(false);
 
 	const viewportRef = useRef<HTMLDivElement>(null);
-	const [following, setFollowing] = useState<boolean>(true);
 	const followingRef = useRef(true);
 	const lastSeqRef = useRef(-1);
 	const pausedSeqRef = useRef(-1);
@@ -76,7 +81,13 @@ export default function Console() {
 		);
 	}, [lines, filter]);
 
-	lastSeqRef.current = lines.length > 0 ? lines[lines.length - 1].seq : -1;
+	useEffect(() => {
+		lastSeqRef.current = lines.length > 0 ? lines[lines.length - 1].seq : -1;
+	}, [lines]);
+
+	useEffect(() => {
+		if (connected) setEverConnected(true);
+	}, [connected]);
 
 	const newCount = following
 		? 0
@@ -155,7 +166,11 @@ export default function Console() {
 				{!connected && (
 					<div className="flex flex-none items-center gap-2 border-b border-amber-500/20 bg-amber-500/10 px-3 pb-2 text-xs text-amber-500">
 						<LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-						<span>Connection lost — reconnecting...</span>
+						<span>
+							{everConnected
+								? 'Connection lost — reconnecting...'
+								: 'Connecting...'}
+						</span>
 					</div>
 				)}
 				{filterOpen && (
@@ -187,7 +202,9 @@ export default function Console() {
 						<div className="p-4 font-mono text-xs leading-relaxed">
 							{lines.length === 0 ? (
 								<p className="text-muted-foreground text-center py-4">
-									No output yet. Start the server to see logs.
+									{serverStatus === 'running'
+										? 'No output to show.'
+										: 'No output yet. Start the server to see logs.'}
 								</p>
 							) : visibleLines.length === 0 ? (
 								<p className="text-muted-foreground text-center py-4">

--- a/packages/shared/src/types/process-manager.ts
+++ b/packages/shared/src/types/process-manager.ts
@@ -15,6 +15,5 @@ export interface ProcessOutputLine {
 	line: string;
 	source: 'stdout' | 'stderr';
 	ts: number;
-	/** Monotonic per core process; stable render key + duplicate detection */
 	seq: number;
 }

--- a/packages/shared/src/types/process-manager.ts
+++ b/packages/shared/src/types/process-manager.ts
@@ -15,4 +15,6 @@ export interface ProcessOutputLine {
 	line: string;
 	source: 'stdout' | 'stderr';
 	ts: number;
+	/** Monotonic per core process; stable render key + duplicate detection */
+	seq: number;
 }


### PR DESCRIPTION
## Description
Bunch of improvements for the console view

- Fix console auto-scroll: the scroll effect never ran on new output, only on checkbox toggle
- Replace the auto-scroll checkbox with devtools-style follow mode: scrolling up pauses, a floating "N new lines" pill jumps back down; line trimming is suspended while scrolled up so the buffer can't shift under the reader
- Intercept `clear` / `cls` client-side to clear the console view instead of erroring as an unknown server command
- Add an output filter (toggle button + bar): case-insensitive, ANSI-stripped matching with a match counter
- Batch console output core-side: lines now broadcast as `lines` arrays with a leading-edge 50ms throttle and a monotonic `seq` per line (stable React keys, duplicate-drop against the initial dump); `LogLine` is memoized so new output no longer re-renders/re-parses the whole list
- Add WebSocket auto-reconnect with exponential backoff (500ms→10s) and subscription replay on reconnect; subscriptions are refcounted, fixing live channels dying when one of several subscriber components unmounted

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [ ] Builds & runs on Windows
- [x] Builds & runs on Linux

---

## Additional Notes
N/A
