### PR TITLE
Ci: fix pr checks running on drafts

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,12 +2,13 @@ name: PR Code Verification
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
     name: Run Unit Tests
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -25,8 +26,9 @@ jobs:
 
   build:
     name: Verify Build System (${{ matrix.os }})
-    needs: test
     runs-on: ${{ matrix.os }}
+    needs: test
+    if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,6 +3,12 @@ name: PR Code Verification
 on:
   pull_request:
     branches: [main]
+    paths:
+      - "apps/**"
+      - "packages/**"
+      - "package.json"
+      - "bun.lockb"
+      - "scripts/build.ts"
 
 jobs:
   test:


### PR DESCRIPTION
## Description

Running all CI/CD workflows on draft pull requests is unnecessary. This change skips these workflows for draft PRs to optimize GitHub Actions runner usage and prevent wasting action minutes until the PR is officially ready for review.

When are the checks from `pr-checks.yml` skipped:
* if the pull request is in a **Draft** state.
* if the changed files are unrelated to core project code (e.g., updates strictly to CI/CD pipelines, documentation, or localizations).

---

## Tests

- N/A
