### PR TITLE
feat: show readable labels instead of raw IDs in audit log & player views

### DIFF
--- a/apps/webpanel/src/pages/players/components/tab-elements.tsx
+++ b/apps/webpanel/src/pages/players/components/tab-elements.tsx
@@ -84,7 +84,7 @@ export function BansTab({
 						<TableCell>
 							<BanStatus ban={ban} />
 						</TableCell>
-						<TableCell>{ban.issuer ?? 'System'}</TableCell>
+						<TableCell>{ban.issuerName ?? 'System'}</TableCell>
 						<TableCell>
 							{ban.expiresAt ? (
 								formatDate(ban.expiresAt)
@@ -126,7 +126,7 @@ export function WarnsTab({
 						<TableCell className="max-w-[300px] truncate">
 							{warn.reason}
 						</TableCell>
-						<TableCell>{warn.issuer ?? 'System'}</TableCell>
+						<TableCell>{warn.issuerName ?? 'System'}</TableCell>
 						<TableCell className="text-muted-foreground text-xs">
 							{formatDate(warn.issuedAt)}
 						</TableCell>
@@ -159,7 +159,7 @@ export function KicksTab({
 						<TableCell className="max-w-[300px] truncate">
 							{kick.reason}
 						</TableCell>
-						<TableCell>{kick.issuer ?? 'System'}</TableCell>
+						<TableCell>{kick.issuerName ?? 'System'}</TableCell>
 						<TableCell className="text-muted-foreground text-xs">
 							{formatDate(kick.issuedAt)}
 						</TableCell>
@@ -189,7 +189,9 @@ export function ReportsTab({ reports }: { reports: PlayerProfile['reports'] }) {
 						<TableCell className="max-w-[260px] truncate">
 							{report.subject}
 						</TableCell>
-						<TableCell>{report.reporterId}</TableCell>
+						<TableCell>
+							{report.reporterName ?? `Player #${report.reporterId}`}
+						</TableCell>
 						<TableCell>
 							<Badge
 								variant={report.status === 'open' ? 'secondary' : 'outline'}
@@ -218,7 +220,8 @@ export function NotesTab({ notes }: { notes: PlayerProfile['notes'] }) {
 				<div key={note.id} className="p-4">
 					<p className="text-sm">{note.content}</p>
 					<p className="text-xs text-muted-foreground mt-2">
-						Added by <span className="font-medium">{note.issuer}</span> ·{' '}
+						Added by{' '}
+						<span className="font-medium">{note.issuerName ?? 'System'}</span> ·{' '}
 						{formatDate(note.issuedAt)}
 					</p>
 				</div>

--- a/apps/webpanel/src/pages/settings/components/auditlog-row.tsx
+++ b/apps/webpanel/src/pages/settings/components/auditlog-row.tsx
@@ -1,5 +1,10 @@
+import { GroupBadge } from '@/components/group-badge';
+import { type AdminGroupEntry, useGroups } from '@/hooks/use-groups';
 import { formatDate } from '@/lib/utils';
+import { PERMISSION_LABELS } from '@fxmanager/shared/constants';
+import { PermissionManager } from '@fxmanager/shared/utils';
 import type { AuditLog } from '@fxmanager/database/types';
+import { Badge } from '@fxmanager/ui/components/badge';
 import { Button } from '@fxmanager/ui/components/button';
 import {
 	ChevronDown,
@@ -31,6 +36,95 @@ const ACTION_ICON_MAP: Record<
 	config: FileSliders,
 };
 
+const META_KEY_LABELS: Record<string, string> = {
+	groupId: 'Group',
+	playerId: 'Player',
+	banId: 'Ban',
+	permissions: 'Permissions',
+	previous_permissions: 'Previous permissions',
+	new_permissions: 'New permissions',
+	previous_groupId: 'Previous group',
+	new_groupId: 'New group',
+	previous_playerId: 'Previous player',
+	new_playerId: 'New player',
+};
+
+const PERMISSION_KEYS = new Set([
+	'permissions',
+	'previous_permissions',
+	'new_permissions',
+]);
+
+function isGroupIdKey(key: string): boolean {
+	return /group_?id$/i.test(key);
+}
+
+function formatMetaKey(key: string): string {
+	if (META_KEY_LABELS[key]) return META_KEY_LABELS[key];
+
+	const spaced = key.replace(/_/g, ' ').replace(/([a-z0-9])([A-Z])/g, '$1 $2');
+	return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function permissionNames(bitfield: number): string[] {
+	if (PermissionManager.isMaster(bitfield)) return ['All permissions'];
+
+	const names = Object.entries(PERMISSION_LABELS)
+		.filter(([bit]) => (bitfield & Number(bit)) !== 0)
+		.map(([, meta]) => meta.label);
+
+	return names.length ? names : ['None'];
+}
+
+function MetaValue({
+	metaKey,
+	value,
+	groups,
+}: {
+	metaKey: string;
+	value: unknown;
+	groups: AdminGroupEntry[];
+}) {
+	if (value === null || value === undefined) {
+		return <span className="italic text-muted-foreground/50">none</span>;
+	}
+
+	if (PERMISSION_KEYS.has(metaKey) && typeof value === 'number') {
+		return (
+			<span className="inline-flex flex-wrap gap-1">
+				{permissionNames(value).map((name) => (
+					<Badge
+						key={name}
+						variant="secondary"
+						className="text-[10px] font-normal px-1.5 py-0"
+					>
+						{name}
+					</Badge>
+				))}
+			</span>
+		);
+	}
+
+	if (isGroupIdKey(metaKey)) {
+		const group = groups.find((g) => g.id === Number(value));
+		if (group) return <GroupBadge group={group} />;
+		return <span className="font-mono">#{String(value)}</span>;
+	}
+
+	if (
+		/id$/i.test(metaKey) &&
+		(typeof value === 'number' || typeof value === 'string')
+	) {
+		return <span className="font-mono">#{String(value)}</span>;
+	}
+
+	if (typeof value === 'object') {
+		return <span className="font-mono">{JSON.stringify(value)}</span>;
+	}
+
+	return <span>{String(value)}</span>;
+}
+
 export function AuditLogRow({
 	log,
 	showAdmin,
@@ -39,6 +133,7 @@ export function AuditLogRow({
 	showAdmin?: boolean;
 }) {
 	const [isExpanded, setIsExpanded] = useState(false);
+	const { groups } = useGroups();
 
 	const group = log.action.split('.')[0] || '';
 	const ActionIcon = ACTION_ICON_MAP[group] || FileQuestion;
@@ -98,9 +193,9 @@ export function AuditLogRow({
 												className="flex flex-col flex-1 gap-0.5 border-r border-border/40 last:border-0 pr-4 last:pr-0 pb-0"
 											>
 												<span className="font-semibold text-foreground/70 text-[11px] uppercase tracking-wider">
-													{key}
+													{formatMetaKey(key)}
 												</span>
-												<span className="font-mono text-muted-foreground text-xs">
+												<span className="text-muted-foreground text-xs">
 													{typeof val === 'object' && val !== null ? (
 														<ul className="space-y-1 list-disc pl-4 mt-1">
 															{Object.entries(val).map(
@@ -111,13 +206,14 @@ export function AuditLogRow({
 																	>
 																		<div className="inline-flex items-start gap-1 text-muted-foreground">
 																			<span className="text-muted-foreground/70 font-semibold shrink-0">
-																				{nestedKey}:
+																				{formatMetaKey(nestedKey)}:
 																			</span>
 																			<span className="text-foreground">
-																				{typeof nestedVal === 'object' &&
-																				nestedVal !== null
-																					? JSON.stringify(nestedVal)
-																					: String(nestedVal)}
+																				<MetaValue
+																					metaKey={nestedKey}
+																					value={nestedVal}
+																					groups={groups}
+																				/>
 																			</span>
 																		</div>
 																	</li>
@@ -125,7 +221,11 @@ export function AuditLogRow({
 															)}
 														</ul>
 													) : (
-														String(val)
+														<MetaValue
+															metaKey={key}
+															value={val}
+															groups={groups}
+														/>
 													)}
 												</span>
 											</div>
@@ -136,9 +236,11 @@ export function AuditLogRow({
 						) : (
 							<div className="flex flex-wrap gap-x-3 gap-y-1 text-muted-foreground/80 font-medium">
 								{Object.entries(log.metadata).map(([key, val]) => (
-									<span key={key} className="inline-block">
-										<span className="text-muted-foreground/50">{key}:</span>{' '}
-										{String(val)}
+									<span key={key} className="inline-flex items-center gap-1">
+										<span className="text-muted-foreground/50">
+											{formatMetaKey(key)}:
+										</span>
+										<MetaValue metaKey={key} value={val} groups={groups} />
 									</span>
 								))}
 							</div>

--- a/packages/database/src/repositories/players.ts
+++ b/packages/database/src/repositories/players.ts
@@ -220,20 +220,70 @@ class PlayersRepository {
 
 		if (!result) return null;
 
-		const identifiers = result.identifiers.reduce((acc, curr) => {
+		const {
+			bans: banRows,
+			warns: warnRows,
+			kicks: kickRows,
+			notes: noteRows,
+			reports: reportRows,
+			identifiers: identifierRows,
+			...player
+		} = result;
+
+		const identifiers = identifierRows.reduce((acc, curr) => {
 			acc[curr.type as keyof PlayerIdentifiers] = curr.value;
 			return acc;
 		}, {} as PlayerIdentifiers);
 
+		const issuerIds = [
+			...new Set(
+				[...banRows, ...warnRows, ...kickRows, ...noteRows]
+					.map((row) => row.issuer)
+					.filter((v): v is number => v != null),
+			),
+		];
+		const reporterIds = [...new Set(reportRows.map((r) => r.reporterId))];
+
+		const adminNames = new Map(
+			issuerIds.length
+				? this.db
+						.select({ id: adminUsers.id, username: adminUsers.username })
+						.from(adminUsers)
+						.where(inArray(adminUsers.id, issuerIds))
+						.all()
+						.map((a) => [a.id, a.username] as const)
+				: [],
+		);
+		const reporterNames = new Map(
+			reporterIds.length
+				? this.db
+						.select({ id: players.id, name: players.name })
+						.from(players)
+						.where(inArray(players.id, reporterIds))
+						.all()
+						.map((p) => [p.id, p.name] as const)
+				: [],
+		);
+
+		const withIssuerName = <T extends { issuer: number | null }>(row: T) => ({
+			...row,
+			issuerName: row.issuer != null ? (adminNames.get(row.issuer) ?? null) : null,
+		});
+
 		return {
-			...result,
+			...player,
 			isStaff: !!result.adminProfile,
 			identifiers,
 			punishments: {
-				bans: result.bans,
-				warns: result.warns,
-				kicks: result.kicks,
+				bans: banRows.map(withIssuerName),
+				warns: warnRows.map(withIssuerName),
+				kicks: kickRows.map(withIssuerName),
 			},
+			notes: noteRows.map(withIssuerName),
+			reports: reportRows.map((r) => ({
+				...r,
+				reporterName: reporterNames.get(r.reporterId) ?? null,
+			})),
 		};
 	}
 

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -17,19 +17,22 @@ export type Ban = typeof bans.$inferSelect;
 export type Warn = typeof warns.$inferSelect;
 export type Kick = typeof kicks.$inferSelect;
 export type PlayerNote = typeof playerNotes.$inferSelect;
+export type Report = typeof reports.$inferSelect;
 export type AdminSelect = Omit<typeof adminUsers.$inferSelect, 'passwordHash'>;
+
+type WithIssuerName<T> = T & { issuerName: string | null };
 
 export interface PlayerProfile extends Player {
 	identifiers: PlayerIdentifiers;
 	isStaff: boolean;
 	adminProfile?: Omit<typeof adminUsers.$inferSelect, 'passwordHash'>;
 	punishments: {
-		bans: (typeof bans.$inferSelect)[];
-		warns: (typeof warns.$inferSelect)[];
-		kicks: (typeof kicks.$inferSelect)[];
+		bans: WithIssuerName<Ban>[];
+		warns: WithIssuerName<Warn>[];
+		kicks: WithIssuerName<Kick>[];
 	};
-	reports: (typeof reports.$inferSelect)[];
-	notes: (typeof playerNotes.$inferSelect)[];
+	reports: (Report & { reporterName: string | null })[];
+	notes: WithIssuerName<PlayerNote>[];
 }
 
 export type { ImportSummary } from './import/txadmin.importer';


### PR DESCRIPTION
## Description

Audit log metadata now resolves group IDs (groupId/previous_groupId/ new_groupId) to group badges, decodes permission bitmasks to labels, and humanizes metadata keys; leftover ID fields render as #n and nulls as "none".

Player punishment, report, and note tables now show issuer usernames and reporter names, resolved via a batched lookup in players.findById (no N+1).

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [ ] Builds & runs on Windows
- [x] Builds & runs on Linux

---

## Additional Notes
N/A
