### PR TITLE
feat: permissions through API and aceperms

### DIFF
--- a/apps/core/src/modules/ace/manager.test.ts
+++ b/apps/core/src/modules/ace/manager.test.ts
@@ -29,21 +29,28 @@ afterAll(() => {
 });
 
 describe('buildAceCommands()', () => {
-	it('should grant one ace per permission bit to the group principal', () => {
+	it('should grant a membership marker then one ace per permission bit to the group principal', () => {
 		const commands = buildAceCommands(
-			[{ id: 3, permissions: UserPermissions.KICK | UserPermissions.BAN }],
+			[
+				{
+					id: 3,
+					name: 'Moderator',
+					permissions: UserPermissions.KICK | UserPermissions.BAN,
+				},
+			],
 			[],
 		);
 
 		expect(commands).toEqual([
-			'add_ace fxmanager.group.3 fxmanager.players.kick allow',
-			'add_ace fxmanager.group.3 fxmanager.players.ban allow',
+			'add_ace fxmanager.group.moderator fxmanager.group.moderator allow',
+			'add_ace fxmanager.group.moderator fxmanager.players.kick allow',
+			'add_ace fxmanager.group.moderator fxmanager.players.ban allow',
 		]);
 	});
 
-	it('should bind linked admins to their group principal', () => {
+	it('should bind linked admins to their slugged group principal', () => {
 		const commands = buildAceCommands(
-			[{ id: 3, permissions: UserPermissions.KICK }],
+			[{ id: 3, name: 'Head Admin', permissions: UserPermissions.KICK }],
 			[
 				{
 					id: 7,
@@ -56,8 +63,25 @@ describe('buildAceCommands()', () => {
 		);
 
 		expect(commands).toContain(
-			'add_principal identifier.license:abc123 fxmanager.group.3',
+			'add_principal identifier.license:abc123 fxmanager.group.head_admin',
 		);
+	});
+
+	it('should skip a group whose name yields an empty slug', () => {
+		const commands = buildAceCommands(
+			[{ id: 8, name: '🎮', permissions: UserPermissions.KICK }],
+			[
+				{
+					id: 1,
+					username: 'x',
+					permissions: 0,
+					groupId: 8,
+					license: 'license:xyz',
+				},
+			],
+		);
+
+		expect(commands).toEqual([]);
 	});
 
 	it('should grant master admins the root ace via the master principal', () => {
@@ -176,8 +200,9 @@ describe('AceSyncManager', () => {
 		aceSync.apply(sender);
 
 		expect(sent).toEqual([
-			'add_ace fxmanager.group.1 fxmanager.players.kick allow',
-			'add_principal identifier.license:abc fxmanager.group.1',
+			'add_ace fxmanager.group.mods fxmanager.group.mods allow',
+			'add_ace fxmanager.group.mods fxmanager.players.kick allow',
+			'add_principal identifier.license:abc fxmanager.group.mods',
 		]);
 	});
 
@@ -226,10 +251,10 @@ describe('AceSyncManager', () => {
 		aceSync.resync(sender);
 
 		expect(sent).toContain(
-			'add_principal identifier.license:abc fxmanager.group.2',
+			'add_principal identifier.license:abc fxmanager.group.devs',
 		);
 		expect(sent).toContain(
-			'remove_principal identifier.license:abc fxmanager.group.1',
+			'remove_principal identifier.license:abc fxmanager.group.mods',
 		);
 	});
 
@@ -241,7 +266,7 @@ describe('AceSyncManager', () => {
 		aceSync.resync(sender);
 
 		expect(sent).toContain(
-			'remove_principal identifier.license:abc fxmanager.group.1',
+			'remove_principal identifier.license:abc fxmanager.group.mods',
 		);
 	});
 
@@ -264,8 +289,8 @@ describe('AceSyncManager', () => {
 		aceSync.resync(sender);
 
 		expect(sent).toEqual([
-			'add_ace fxmanager.group.1 fxmanager.players.ban allow',
-			'remove_ace fxmanager.group.1 fxmanager.players.kick allow',
+			'add_ace fxmanager.group.mods fxmanager.players.ban allow',
+			'remove_ace fxmanager.group.mods fxmanager.players.kick allow',
 		]);
 	});
 
@@ -273,8 +298,9 @@ describe('AceSyncManager', () => {
 		aceSync.resync(sender);
 
 		expect(sent).toEqual([
-			'add_ace fxmanager.group.1 fxmanager.players.kick allow',
-			'add_principal identifier.license:abc fxmanager.group.1',
+			'add_ace fxmanager.group.mods fxmanager.group.mods allow',
+			'add_ace fxmanager.group.mods fxmanager.players.kick allow',
+			'add_principal identifier.license:abc fxmanager.group.mods',
 		]);
 	});
 
@@ -305,7 +331,7 @@ describe('AceSyncManager', () => {
 		aceSync.refresh();
 
 		expect(sent).toEqual([
-			'add_principal identifier.license:def fxmanager.group.1',
+			'add_principal identifier.license:def fxmanager.group.mods',
 		]);
 	});
 

--- a/apps/core/src/modules/ace/manager.ts
+++ b/apps/core/src/modules/ace/manager.ts
@@ -4,12 +4,13 @@ import {
 	PERMISSION_ACE_KEYS,
 	UserPermissions,
 } from '@fxmanager/shared/constants';
-import { PermissionManager } from '@fxmanager/shared/utils';
+import { PermissionManager, slugifyGroupName } from '@fxmanager/shared/utils';
 
 type CommandSender = { sendCommand(command: string): void };
 
 interface AceGroup {
 	id: number;
+	name: string;
 	permissions: number;
 }
 
@@ -36,9 +37,18 @@ export function buildAceCommands(
 	admins: AceAdmin[],
 ): string[] {
 	const commands: string[] = [];
+	const slugById = new Map<number, string>();
 
 	for (const group of groups) {
-		pushBitAces(commands, `${ACE_PREFIX}.group.${group.id}`, group.permissions);
+		const slug = slugifyGroupName(group.name);
+		if (!slug) continue;
+
+		slugById.set(group.id, slug);
+
+		const principal = `${ACE_PREFIX}.group.${slug}`;
+		// self-marker so membership is checkable via IsPlayerAceAllowed / hasGroup
+		commands.push(`add_ace ${principal} ${principal} allow`);
+		pushBitAces(commands, principal, group.permissions);
 	}
 
 	const linked = admins.filter((admin) => {
@@ -66,9 +76,12 @@ export function buildAceCommands(
 		}
 
 		if (admin.groupId !== null) {
-			commands.push(
-				`add_principal ${identity} ${ACE_PREFIX}.group.${admin.groupId}`,
-			);
+			const slug = slugById.get(admin.groupId);
+			if (slug) {
+				commands.push(
+					`add_principal ${identity} ${ACE_PREFIX}.group.${slug}`,
+				);
+			}
 		}
 
 		const personal = admin.permissions & ~UserPermissions.MASTER;

--- a/apps/core/src/routes/api/settings/groups.ts
+++ b/apps/core/src/routes/api/settings/groups.ts
@@ -14,6 +14,16 @@ interface GroupBody {
 	icon?: string | null;
 }
 
+function groupErrorMessage(message: string): string {
+	if (message === 'invalid_slug')
+		return 'Group name must contain at least one letter or number';
+	if (message === 'slug_conflict')
+		return 'Group name conflicts with an existing group';
+	if (message.includes('UNIQUE constraint failed'))
+		return 'Group name is already taken';
+	return message;
+}
+
 const GroupManagementEndpoints: RouteModule['handler'] = async (
 	fastify,
 	{ pm },
@@ -63,13 +73,7 @@ const GroupManagementEndpoints: RouteModule['handler'] = async (
 
 			return { success: true, data: group };
 		} catch (err) {
-			const message = (err as Error).message;
-			return {
-				success: false,
-				error: message.includes('UNIQUE constraint failed')
-					? 'Group name is already taken'
-					: message,
-			};
+			return { success: false, error: groupErrorMessage((err as Error).message) };
 		}
 	});
 
@@ -112,8 +116,10 @@ const GroupManagementEndpoints: RouteModule['handler'] = async (
 
 				if (message === 'not_found')
 					return { success: false, error: 'Group not found' };
-				if (message.includes('UNIQUE constraint failed'))
-					return { success: false, error: 'Group name is already taken' };
+
+				const friendly = groupErrorMessage(message);
+				if (friendly !== message)
+					return { success: false, error: friendly };
 
 				throw err;
 			}

--- a/apps/core/src/routes/api/setup.ts
+++ b/apps/core/src/routes/api/setup.ts
@@ -116,8 +116,15 @@ const SetupEndpoint: FastifyPluginAsync = async (fastify) => {
 						});
 					}
 				} catch (err) {
+					const message = (err as Error).message;
+					const detail =
+						message === 'slug_conflict'
+							? 'two groups resolve to the same name'
+							: message === 'invalid_slug'
+								? 'a group name has no letters or numbers'
+								: message;
 					return reply.code(400).send({
-						error: `Failed to store admin groups: ${(err as Error).message}`,
+						error: `Failed to store admin groups: ${detail}`,
 					});
 				}
 			}

--- a/apps/resource/src/server/exports.ts
+++ b/apps/resource/src/server/exports.ts
@@ -1,5 +1,6 @@
 import { ACE_PREFIX } from '@fxmanager/shared/constants';
 import type { PlayerIdentifiers } from '@fxmanager/shared/types';
+import { slugifyGroupName } from '@fxmanager/shared/utils';
 import { QueryManager } from './utils/query';
 
 type Target =
@@ -63,6 +64,19 @@ exports(
 		return IsPlayerAceAllowed(
 			String(playerId),
 			`${ACE_PREFIX}.${permissionKey}`,
+		);
+	},
+);
+
+exports(
+	'hasGroup',
+	(playerId: number | string, groupName: string): boolean => {
+		const slug = slugifyGroupName(groupName);
+		if (!slug) return false;
+
+		return IsPlayerAceAllowed(
+			String(playerId),
+			`${ACE_PREFIX}.group.${slug}`,
 		);
 	},
 );

--- a/packages/database/src/repositories/groups.test.ts
+++ b/packages/database/src/repositories/groups.test.ts
@@ -96,6 +96,20 @@ describe('GroupsRepository', () => {
 				groupsRepo.create({ name: 'Staff', permissions: 0, colour: '#fff' }),
 			).toThrow(/UNIQUE/);
 		});
+
+		it('should reject a name that collides with an existing slug', () => {
+			insertGroup('Head Admin');
+
+			expect(() =>
+				groupsRepo.create({ name: 'Head-Admin', permissions: 0, colour: '#fff' }),
+			).toThrow('slug_conflict');
+		});
+
+		it('should reject a name with no slug-safe characters', () => {
+			expect(() =>
+				groupsRepo.create({ name: '🎮', permissions: 0, colour: '#fff' }),
+			).toThrow('invalid_slug');
+		});
 	});
 
 	describe('update()', () => {
@@ -115,6 +129,31 @@ describe('GroupsRepository', () => {
 		it('should throw not_found for a missing group', () => {
 			expect(() => groupsRepo.update(999, { name: 'Ghost' })).toThrow(
 				'not_found',
+			);
+		});
+
+		it('should reject renaming onto another group’s slug', () => {
+			insertGroup('Moderator');
+			const devs = insertGroup('Developers');
+
+			expect(() =>
+				groupsRepo.update(devs.id, { name: 'moderator' }),
+			).toThrow('slug_conflict');
+		});
+
+		it('should allow a rename that keeps the same slug for the same group', () => {
+			const group = insertGroup('Moderator');
+
+			const updated = groupsRepo.update(group.id, { name: 'MODERATOR' });
+
+			expect(updated.name).toBe('MODERATOR');
+		});
+
+		it('should reject renaming to a slug-empty name', () => {
+			const group = insertGroup('Moderator');
+
+			expect(() => groupsRepo.update(group.id, { name: '!!!' })).toThrow(
+				'invalid_slug',
 			);
 		});
 	});

--- a/packages/database/src/repositories/groups.ts
+++ b/packages/database/src/repositories/groups.ts
@@ -4,6 +4,7 @@ import type * as schema from '../schema';
 import { adminGroups, adminUsers } from '../schema';
 import { UserPermissions } from '@fxmanager/shared/constants';
 import type { AdminGroupForm } from '@fxmanager/shared/types';
+import { slugifyGroupName } from '@fxmanager/shared/utils';
 
 type DB = BunSQLiteDatabase<typeof schema>;
 
@@ -48,7 +49,28 @@ class GroupsRepository {
 		);
 	}
 
+	// names map to `fxmanager.group.<slug>` aces, so slugs must be unique
+	private assertSlugAvailable(name: string, excludeId: number | null) {
+		const slug = slugifyGroupName(name);
+		if (!slug) throw new Error('invalid_slug');
+
+		const clash = this.db
+			.select({ id: adminGroups.id, name: adminGroups.name })
+			.from(adminGroups)
+			.all()
+			.find(
+				(g) =>
+					g.id !== excludeId &&
+					g.name !== name &&
+					slugifyGroupName(g.name) === slug,
+			);
+
+		if (clash) throw new Error('slug_conflict');
+	}
+
 	create(form: AdminGroupForm) {
+		this.assertSlugAvailable(form.name, null);
+
 		return this.db
 			.insert(adminGroups)
 			.values({
@@ -63,6 +85,9 @@ class GroupsRepository {
 	}
 
 	update(groupId: number, patch: Partial<AdminGroupForm>) {
+		if (patch.name !== undefined)
+			this.assertSlugAvailable(patch.name, groupId);
+
 		const updated = this.db
 			.update(adminGroups)
 			.set({

--- a/packages/shared/src/utils/group-slug.test.ts
+++ b/packages/shared/src/utils/group-slug.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'bun:test';
+import { slugifyGroupName } from './group-slug';
+
+describe('slugifyGroupName()', () => {
+	it('should lowercase and keep simple names', () => {
+		expect(slugifyGroupName('Moderator')).toBe('moderator');
+	});
+
+	it('should replace whitespace runs with a single underscore', () => {
+		expect(slugifyGroupName('Head Admin')).toBe('head_admin');
+		expect(slugifyGroupName('Head   Admin')).toBe('head_admin');
+	});
+
+	it('should treat dashes like spaces', () => {
+		expect(slugifyGroupName('Head-Admin')).toBe('head_admin');
+	});
+
+	it('should strip characters outside [a-z0-9_]', () => {
+		expect(slugifyGroupName('Moderator!!')).toBe('moderator');
+		expect(slugifyGroupName('super/admin')).toBe('superadmin');
+	});
+
+	it('should trim leading and trailing underscores', () => {
+		expect(slugifyGroupName('  Moderator  ')).toBe('moderator');
+		expect(slugifyGroupName('_mod_')).toBe('mod');
+	});
+
+	it('should keep digits', () => {
+		expect(slugifyGroupName('Level 3')).toBe('level_3');
+	});
+
+	it('should return empty string when nothing survives', () => {
+		expect(slugifyGroupName('🎮')).toBe('');
+		expect(slugifyGroupName('   ')).toBe('');
+		expect(slugifyGroupName('')).toBe('');
+	});
+
+	it('should neutralise console-command injection attempts', () => {
+		expect(slugifyGroupName('mod allow; quit')).toBe('mod_allow_quit');
+	});
+
+	it('should be safe against non-string input', () => {
+		// biome-ignore lint/suspicious/noExplicitAny: guarding runtime misuse
+		expect(slugifyGroupName(undefined as any)).toBe('');
+	});
+});

--- a/packages/shared/src/utils/group-slug.ts
+++ b/packages/shared/src/utils/group-slug.ts
@@ -1,0 +1,10 @@
+export function slugifyGroupName(name: string): string {
+	if (typeof name !== 'string') return '';
+	return name
+		.toLowerCase()
+		.trim()
+		.replace(/[\s-]+/g, '_')
+		.replace(/[^a-z0-9_]/g, '')
+		.replace(/_+/g, '_')
+		.replace(/^_+|_+$/g, '');
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './group-slug';
 export * from './permissions';
 export * from './resource-name';
 export * from './settings-access';


### PR DESCRIPTION
## Description
New feature for ingame api, now we can directly check if a user is part of a fxmanager group such as moderator by doing:

```lua
exports.fxManager:isInGroup(source, 'moderator')
```

or

```lua
IsPlayerAceAllowed(source, 'fxmanager.group.moderator')
```

Which then adds support for each server being able to add permissions to their resources/server through their resource or server.cfg by doing:

```
add_ace fxmanager.group.moderator car.spawn allow
``` 

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [x] Builds & runs on Windows
- [x] Builds & runs on Linux

---
N/A
