### PR TITLE
Fix: core doesn't open setup url in browser

### DIFF
--- a/apps/core/src/common/utils.ts
+++ b/apps/core/src/common/utils.ts
@@ -1,13 +1,9 @@
 import os from 'os';
 import { randomBytes } from 'node:crypto';
 import { repo } from '@fxmanager/database';
-import open from 'open';
 
 export const isProduction = process.env.NODE_ENV === 'production';
 export const COOKIE_NAME = 'fxm_session';
-
-const osType = os.platform();
-export const isWindows = osType === 'win32';
 
 export function isFxManagerSetup() {
 	return repo.auth.countUsers() > 0;
@@ -40,9 +36,4 @@ export function getIp(): string {
 		}
 	}
 	return '127.0.0.1';
-}
-
-export function openUrlInBrowser(url: string): void {
-	if (isWindows) return;
-	open(url).catch(() => {});
 }

--- a/apps/core/src/common/utils.ts
+++ b/apps/core/src/common/utils.ts
@@ -1,9 +1,13 @@
 import os from 'os';
 import { randomBytes } from 'node:crypto';
 import { repo } from '@fxmanager/database';
+import open from 'open';
 
 export const isProduction = process.env.NODE_ENV === 'production';
 export const COOKIE_NAME = 'fxm_session';
+
+const osType = os.platform();
+export const isWindows = osType === 'win32';
 
 export function isFxManagerSetup() {
 	return repo.auth.countUsers() > 0;
@@ -36,4 +40,9 @@ export function getIp(): string {
 		}
 	}
 	return '127.0.0.1';
+}
+
+export function openUrlInBrowser(url: string): void {
+	if (isWindows) return;
+	open(url).catch(() => {});
 }

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -3,12 +3,16 @@ import './common/env';
 import path, { join } from 'node:path';
 import { readFileSync } from 'node:fs';
 import Fastify from 'fastify';
-import open from 'open';
 import fastifyStatic from '@fastify/static';
 import fastifyWebsocket from '@fastify/websocket';
 import fastifyCookie from '@fastify/cookie';
 import { applyMigrations } from '@fxmanager/database';
-import { getIp, isFxManagerSetup, isProduction } from './common/utils';
+import {
+	getIp,
+	isFxManagerSetup,
+	isProduction,
+	openUrlInBrowser,
+} from './common/utils';
 import { checkVersion } from './common/version_check';
 import apiRoutes from './routes/api';
 import internalRoutes from './routes/internal';
@@ -48,7 +52,7 @@ if (!isFxManagerSetup()) {
 			`\t${localhostUrl}`,
 	);
 
-	open(localhostUrl);
+	openUrlInBrowser(localhostUrl);
 }
 const fastify = Fastify({ logger: !isProduction, forceCloseConnections: true });
 

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -24,6 +24,7 @@ import { sessionManager } from './modules/session/manager';
 import { restartScheduler } from './modules/schedule/manager';
 import { setupTokenManager } from './modules/setup/token';
 import { MIGRATE_WORKER_FLAG, runMigrateWorker } from './migrate-worker';
+import open from 'open';
 
 const ip = getIp();
 
@@ -52,7 +53,7 @@ if (!isFxManagerSetup()) {
 			`\t${localhostUrl}`,
 	);
 
-	openUrlInBrowser(localhostUrl);
+	open(localhostUrl).catch(() => {});
 }
 const fastify = Fastify({ logger: !isProduction, forceCloseConnections: true });
 

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -7,12 +7,7 @@ import fastifyStatic from '@fastify/static';
 import fastifyWebsocket from '@fastify/websocket';
 import fastifyCookie from '@fastify/cookie';
 import { applyMigrations } from '@fxmanager/database';
-import {
-	getIp,
-	isFxManagerSetup,
-	isProduction,
-	openUrlInBrowser,
-} from './common/utils';
+import { getIp, isFxManagerSetup, isProduction } from './common/utils';
 import { checkVersion } from './common/version_check';
 import apiRoutes from './routes/api';
 import internalRoutes from './routes/internal';


### PR DESCRIPTION
## Description

Issue was encountered by users running the panel on a server without a desktop, the open library tries to open the setup panel but fails as it doesn't find the `xdg-open` path causing it to error.
This PR addresses it and not only limits the feature to windows but also runs it in a try/catch block.

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [ ] Builds & runs on Windows
- [ ] Builds & runs on Linux

---

## Additional Notes

<!--
	Any extra details you wish to share, i.e.:
	* Unable to test on linux -> state why for context
	* Request feedback
	* Explain why the PR is listed as a Draft
	* List todo steps requiring discussion
-->
