### PR TITLE
Fix: censor internal convars post load

### DIFF
--- a/apps/resource/src/server/index.ts
+++ b/apps/resource/src/server/index.ts
@@ -2,3 +2,6 @@ import './txadmin';
 import './events';
 import './httphandler';
 import './exports';
+import { censorConvars } from './utils/env';
+
+censorConvars();

--- a/apps/resource/src/server/monitoring/players.test.ts
+++ b/apps/resource/src/server/monitoring/players.test.ts
@@ -6,6 +6,7 @@ const g = globalThis as Globalish;
 g.GetConvar = (key: string, def: string) =>
 	key === 'resource-api-token' ? '00000000-0000-4000-8000-000000000000' : def;
 g.GetConvarInt = (_key: string, def: number) => def;
+g.SetConvar = (_key: string, def: number) => undefined;
 
 const { playerManager } = await import('./players');
 

--- a/apps/resource/src/server/utils/env.ts
+++ b/apps/resource/src/server/utils/env.ts
@@ -7,4 +7,9 @@ const uuidV4Regex =
 if (!uuidV4Regex.test(API_TOKEN))
 	throw new Error('An invalid api token was loaded !');
 
+export function censorConvars() {
+	SetConvar('resource-api-token', 'REDACTED');
+	SetConvar('api-port', 'REDACTED');
+}
+
 export { API_TOKEN, PORT, HOSTNAME };


### PR DESCRIPTION
## Description

Convar values (`resource-api-token` & `api-port`) are accessible by clients with the `commands` ace permission (generally attributed to `group.admin` by tx.
This PR addresses this issue by "censoring" the values once they've been loaded into memory by the resource.

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [x] Builds & runs on Windows
- [x] Builds & runs on Linux

---

## Additional Notes

<!--
	Any extra details you wish to share, i.e.:
	* Unable to test on linux -> state why for context
	* Request feedback
	* Explain why the PR is listed as a Draft
	* List todo steps requiring discussion
-->
