### PR TITLE
feat(api): add actionRecap & getActionRecap

### DIFF
--- a/apps/core/src/routes/internal/ingame.integration.test.ts
+++ b/apps/core/src/routes/internal/ingame.integration.test.ts
@@ -104,7 +104,32 @@ const mockWhitelistAdd = mock((_data: unknown) => true as const);
 const mockWhitelistRevoke = mock((value: string) =>
 	value === 'license:missing' ? undefined : { id: 1, value },
 );
-const mockAuditLog = mock((_entry: unknown) => {});
+const mockAuditLog = mock((_entry: unknown) => ({ id: 800 }));
+const mockAuditList = mock(
+	(
+		page: number,
+		pageSize: number,
+		_action?: unknown,
+		_target?: unknown,
+		admins?: number[],
+	) => ({
+		items: [
+			{
+				id: 1,
+				admin: 'FjamZoo',
+				adminId: admins?.[0] ?? null,
+				action: 'player.kick',
+				playerId: 10,
+				player: 'Alice',
+				metadata: { source: 'ingame-api' },
+				createdAt: new Date(0),
+			},
+		],
+		total: 1,
+		page,
+		pageSize,
+	}),
+);
 
 const fakeRepo = {
 	players: {
@@ -122,7 +147,7 @@ const fakeRepo = {
 	bans: { search: mockBansSearch, revoke: mockBansRevoke },
 	admins: { findByPlayerId: mockFindAdmin },
 	whitelist: { add: mockWhitelistAdd, revokeByValue: mockWhitelistRevoke },
-	audit: { log: mockAuditLog },
+	audit: { log: mockAuditLog, list: mockAuditList },
 };
 
 const mockEmit = mock(async (_event: string, _data: unknown) => {});
@@ -197,6 +222,7 @@ describe('ingame API integration (HTTP)', () => {
 			mockWhitelistAdd,
 			mockWhitelistRevoke,
 			mockAuditLog,
+			mockAuditList,
 			mockEmit,
 			dropPlayer,
 			pmStart,
@@ -469,5 +495,84 @@ describe('ingame API integration (HTTP)', () => {
 		const failed = await call('POST', '/server/start', {});
 		expect(failed.statusCode).toBe(500);
 		expect(failed.json().message).toBe('server_action_failed');
+	});
+
+	it('records a custom action recap under the acting admin', async () => {
+		const res = await call('POST', '/recap', {
+			serverId: 1,
+			label: 'freeze',
+			target: 2,
+			metadata: { seconds: 60 },
+		});
+		expect(res.statusCode).toBe(200);
+		expect(res.json() as any).toEqual({ recapId: 800 });
+		expect(mockAuditLog).toHaveBeenCalledTimes(1);
+		expect(mockAuditLog.mock.calls[0]?.[0]).toMatchObject({
+			adminId: 4,
+			action: 'custom.action',
+			playerId: 20,
+			metadata: {
+				label: 'freeze',
+				seconds: 60,
+				source: 'ingame-api',
+			},
+		});
+	});
+
+	it('records a custom action recap without a target', async () => {
+		const res = await call('POST', '/recap', {
+			serverId: 1,
+			label: 'announce',
+		});
+		expect(res.statusCode).toBe(200);
+		expect(mockAuditLog.mock.calls[0]?.[0]).toMatchObject({
+			adminId: 4,
+			action: 'custom.action',
+			metadata: { label: 'announce', source: 'ingame-api' },
+		});
+		expect((mockAuditLog.mock.calls[0]?.[0] as any).playerId).toBeUndefined();
+	});
+
+	it('requires the acting admin to resolve for a custom recap', async () => {
+		const res = await call('POST', '/recap', { serverId: 2, label: 'freeze' });
+		expect(res.statusCode).toBe(400);
+		expect(res.json().message).toBe('actor_required');
+		expect(mockAuditLog).not.toHaveBeenCalled();
+	});
+
+	it('rejects a custom recap with a missing or malformed label', async () => {
+		const missing = await call('POST', '/recap', { serverId: 1 });
+		expect(missing.statusCode).toBe(400);
+		expect(missing.json().message).toBe('invalid_label');
+
+		const bad = await call('POST', '/recap', {
+			serverId: 1,
+			label: 'NOT VALID!',
+		});
+		expect(bad.statusCode).toBe(400);
+		expect(bad.json().message).toBe('invalid_label');
+
+		expect(mockAuditLog).not.toHaveBeenCalled();
+	});
+
+	it('fetches an action recap by admin id', async () => {
+		const res = await call('GET', '/recap?adminId=4');
+		expect(res.statusCode).toBe(200);
+		expect(mockAuditList).toHaveBeenCalledWith(1, 50, undefined, undefined, [4]);
+		expect(res.json().items).toHaveLength(1);
+		expect(res.json().total).toBe(1);
+	});
+
+	it('fetches an action recap by acting server id with paging', async () => {
+		const res = await call('GET', '/recap?serverId=1&page=2&pageSize=10');
+		expect(res.statusCode).toBe(200);
+		expect(mockAuditList).toHaveBeenCalledWith(2, 10, undefined, undefined, [4]);
+	});
+
+	it('400s an action recap lookup with no resolvable admin', async () => {
+		const res = await call('GET', '/recap');
+		expect(res.statusCode).toBe(400);
+		expect(res.json().message).toBe('admin_required');
+		expect(mockAuditList).not.toHaveBeenCalled();
 	});
 });

--- a/apps/core/src/routes/internal/ingame.ts
+++ b/apps/core/src/routes/internal/ingame.ts
@@ -565,6 +565,80 @@ const IngameEndpoints: RouteModule['handler'] = async (fastify, options) => {
 		return { removed: true };
 	});
 
+	fastify.post('/recap', (request, reply) => {
+		const body = request.body as {
+			serverId?: number;
+			label?: unknown;
+			target?: unknown;
+			metadata?: unknown;
+			resource?: string;
+		};
+
+		const label = typeof body.label === 'string' ? body.label.trim() : '';
+		if (!/^[a-z0-9_.-]{1,48}$/.test(label))
+			return reply.code(400).send({ message: 'invalid_label' });
+
+		const acting = resolveIssuer(body.serverId, issuerDeps);
+		if (!acting) return reply.code(400).send({ message: 'actor_required' });
+
+		let playerId: number | undefined;
+		if (body.target !== undefined && body.target !== null) {
+			const target = parseTarget(body.target);
+			if (!target) return reply.code(400).send({ message: 'invalid_target' });
+			const resolved = resolveTarget(target, targetDeps);
+			if (!resolved)
+				return reply.code(404).send({ message: 'player_not_found' });
+			playerId = resolved.playerId;
+		}
+
+		const metadata =
+			body.metadata && typeof body.metadata === 'object'
+				? (body.metadata as Record<string, unknown>)
+				: {};
+
+		const entry = repo.audit.log({
+			adminId: acting.id,
+			action: 'custom.action',
+			playerId,
+			metadata: {
+				...metadata,
+				label,
+				source: 'ingame-api',
+				resource: body.resource ?? null,
+			},
+		});
+
+		return { recapId: entry.id };
+	});
+
+	fastify.get('/recap', (request, reply) => {
+		const q = request.query as {
+			adminId?: string;
+			serverId?: string;
+			page?: string;
+			pageSize?: string;
+		};
+
+		let adminId: number | null = null;
+		const parsedAdminId = q.adminId ? Number(q.adminId) : Number.NaN;
+		if (Number.isInteger(parsedAdminId) && parsedAdminId > 0) {
+			adminId = parsedAdminId;
+		} else if (q.serverId) {
+			adminId = resolveIssuer(Number(q.serverId), issuerDeps)?.id ?? null;
+		}
+
+		if (adminId === null)
+			return reply.code(400).send({ message: 'admin_required' });
+
+		return repo.audit.list(
+			parsePage(q.page) ?? 1,
+			parsePage(q.pageSize) ?? 50,
+			undefined,
+			undefined,
+			[adminId],
+		);
+	});
+
 	const runServerAction = async (
 		body: { by?: number; resource?: string },
 		action: 'server.start' | 'server.stop' | 'server.restart',

--- a/apps/resource/src/server/exports.ts
+++ b/apps/resource/src/server/exports.ts
@@ -151,6 +151,27 @@ exports('addNote', (input: { target: Target; content: string; by: number }) =>
 	post('/ingame/notes', input),
 );
 
+exports(
+	'actionRecap',
+	(input: {
+		serverId: number;
+		label: string;
+		target?: Target;
+		metadata?: Record<string, unknown>;
+	}) => post('/ingame/recap', input),
+);
+
+exports(
+	'getActionRecap',
+	(opts: PageOpts & { adminId?: number; serverId?: number }) => {
+		const params = pageParams(opts);
+		if (opts.adminId !== undefined) params.set('adminId', String(opts.adminId));
+		if (opts.serverId !== undefined)
+			params.set('serverId', String(opts.serverId));
+		return get(`/ingame/recap${qs(params)}`);
+	},
+);
+
 exports('whitelistAdd', (input: { type: string; value: string; by?: number }) =>
 	post('/ingame/whitelist', input),
 );

--- a/apps/webpanel/src/pages/settings/components/auditlog-row.tsx
+++ b/apps/webpanel/src/pages/settings/components/auditlog-row.tsx
@@ -13,6 +13,7 @@ import {
 	FileQuestion,
 	FileSliders,
 	MessagesSquare,
+	Puzzle,
 	ScanEye,
 	Server,
 	Shield,
@@ -34,6 +35,7 @@ const ACTION_ICON_MAP: Record<
 	settings: Cog,
 	migrate: Upload,
 	config: FileSliders,
+	custom: Puzzle,
 };
 
 const META_KEY_LABELS: Record<string, string> = {

--- a/packages/shared/src/constants/audit.ts
+++ b/packages/shared/src/constants/audit.ts
@@ -17,4 +17,5 @@ export const AUDIT_LOG_ACTIONS = {
 	SETTINGS: ['settings.update'],
 	CONFIG: ['config.update'],
 	MIGRATE: ['migrate.txadmin'],
+	CUSTOM: ['custom.action'],
 } as const;


### PR DESCRIPTION
## Description
Adds API parity for action recaps for admins.

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [x] Builds & runs on Windows
- [x] Builds & runs on Linux

---

## Additional Notes
N/A
