### PR TITLE
feat: add configurable startup arguments

### DIFF
--- a/apps/core/src/modules/process/manager.test.ts
+++ b/apps/core/src/modules/process/manager.test.ts
@@ -22,6 +22,7 @@ import { txAdminCompat } from '../txadmin/compat';
 
 const mockGetHistory = mock(() => []);
 const mockBufferPush = mock(() => {});
+const mockSettingsGet = mock(() => undefined);
 
 const mockRegenerateApiToken = mock(() => {});
 const mockGetSystemValues = mock(() => ({
@@ -34,6 +35,12 @@ const mockGetFxServerValues = mock(() => ({
 	executablePath: 'FXServer.exe',
 	serverDataPath: '/home/fxserver/server-data',
 	serverConfigFile: 'server.cfg',
+}));
+
+mock.module('@fxmanager/database', () => ({
+	repo: {
+		settings: { get: mockSettingsGet },
+	},
 }));
 
 // Use spyOn to safely intercept instances without corrupting Bun's global module cache

--- a/apps/core/src/modules/process/manager.ts
+++ b/apps/core/src/modules/process/manager.ts
@@ -76,7 +76,8 @@ export class ProcessManager {
 			'+add_convar_permission', 'fxManager', 'read', 'api-port',
 		];
 
-		const configuredArgs = repo.settings.get("fxserver.startupArguments")?.split(' ') ?? [];
+		const configuredArgs =
+			repo.settings.get('fxserver.startupArguments')?.split(' ') ?? [];
 		args.push(...configuredArgs);
 
 		console.log(`[core] Starting fxServer`);

--- a/apps/core/src/modules/process/manager.ts
+++ b/apps/core/src/modules/process/manager.ts
@@ -15,6 +15,7 @@ import { disconnectManager } from '../disconnect/manager';
 import { sessionManager } from '../session/manager';
 import { gameManager } from '../game/manager';
 import { txAdminCompat } from '../txadmin/compat';
+import { repo } from '@fxmanager/database';
 
 const STARTUP_STALL_MS = 90_000;
 const KILL_GRACE_MS = 5_000;
@@ -74,6 +75,9 @@ export class ProcessManager {
 			'+add_convar_permission', 'fxManager', 'read', 'resource-api-token',
 			'+add_convar_permission', 'fxManager', 'read', 'api-port',
 		];
+
+		const configuredArgs = repo.settings.get("fxserver.startupArguments")?.split(' ') ?? [];
+		args.push(...configuredArgs);
 
 		console.log(`[core] Starting fxServer`);
 

--- a/apps/core/src/routes/api/settings/index.ts
+++ b/apps/core/src/routes/api/settings/index.ts
@@ -8,7 +8,11 @@ import type {
 	SettingsKey,
 	SettingsScope,
 } from '@fxmanager/shared/types';
-import { PermissionManager, canWriteSetting } from '@fxmanager/shared/utils';
+import {
+	PermissionManager,
+	canWriteSetting,
+	validateStartupArguments,
+} from '@fxmanager/shared/utils';
 import {
 	SETTINGS_KEYS,
 	SETTINGS_SCOPES,
@@ -17,6 +21,17 @@ import {
 } from '@fxmanager/shared/constants';
 import { repo } from '@fxmanager/database';
 import { restartScheduler } from '../../../modules/schedule/manager';
+
+interface HookResult {
+	valid: boolean;
+	[key: string]: unknown;
+}
+
+const SETTINGS_HOOKS: Partial<
+	Record<SettingsKey, (value: string) => HookResult>
+> = {
+	'fxserver.startupArguments': validateStartupArguments,
+};
 
 const SettingsEndpoints: RouteModule['handler'] = async (
 	fastify,
@@ -78,6 +93,11 @@ const SettingsEndpoints: RouteModule['handler'] = async (
 
 		if (!canWriteSetting(key as SettingsKey, admin.permissions)) {
 			throw new Error('Unauthorized');
+		}
+
+		const hook = SETTINGS_HOOKS[key as SettingsKey];
+		if (hook && !hook(value).valid) {
+			throw new Error('Invalid value');
 		}
 
 		repo.settings.set(key, value);

--- a/apps/webpanel/src/pages/settings/tabs/fxserver.tsx
+++ b/apps/webpanel/src/pages/settings/tabs/fxserver.tsx
@@ -10,6 +10,65 @@ import { SETTINGS_DEFAULTS } from '@fxmanager/shared/constants';
 import type { SettingsTabProps } from '@/types/settings';
 import { Separator } from '@fxmanager/ui/components/separator';
 import { Input } from '@fxmanager/ui/components/input';
+import { Field, FieldDescription } from '@fxmanager/ui/components/field';
+import { useState } from 'react';
+
+const RESTRICTED_ARGS = [
+	'+set onesync',
+	'+set resource-api-token',
+	'+set api-port',
+	'+ensure fxManager',
+	'+add_convar_permission fxManager read resource-api-token',
+	'+add_convar_permission fxManager read api-port',
+];
+
+function checkStartupArguments(args: string) {
+	if (!args) return '';
+
+	const restricted = RESTRICTED_ARGS.find((arg) => args.includes(arg));
+	if (!restricted) return '';
+
+	return `"${restricted}" is not allowed here.`;
+}
+
+function blur(event: React.KeyboardEvent<HTMLInputElement>) {
+	if (event.key !== 'Enter') return;
+	event.currentTarget.blur();
+}
+
+function StartupArgumentsField({
+	value: defaultValue,
+	disabled,
+	onChange,
+}: {
+	value: string;
+	disabled: boolean;
+	onChange: (value: string) => void;
+}) {
+	const [error, setError] = useState('');
+
+	return (
+		<Field data-invalid={error !== ''} className="gap-0.5">
+			<Input
+				defaultValue={defaultValue}
+				disabled={disabled}
+				placeholder={'+exec server.cfg'}
+				onBlur={(event) => {
+					const value = event.currentTarget.value.trim();
+					const validationError = checkStartupArguments(value);
+
+					setError(validationError);
+
+					if (validationError) return;
+
+					onChange(value);
+				}}
+				onKeyDown={blur}
+			/>
+			<FieldDescription>{error}</FieldDescription>
+		</Field>
+	);
+}
 
 export default function FXServerTab({
 	data,
@@ -18,6 +77,7 @@ export default function FXServerTab({
 }: SettingsTabProps<'fxserver'>) {
 	const onesync =
 		data['fxserver.onesync'] ?? SETTINGS_DEFAULTS['fxserver.onesync'];
+	const startupArguments = data['fxserver.startupArguments'] ?? '';
 	const serverDataPath =
 		data['fxserver.serverDataPath'] ??
 		SETTINGS_DEFAULTS['fxserver.serverDataPath'];
@@ -27,11 +87,6 @@ export default function FXServerTab({
 	const serverConfigPath =
 		data['fxserver.serverConfigPath'] ??
 		SETTINGS_DEFAULTS['fxserver.serverConfigPath'];
-
-	function blur(event: React.KeyboardEvent<HTMLInputElement>) {
-		if (event.key !== 'Enter') return;
-		event.currentTarget.blur();
-	}
 
 	return (
 		<div className="space-y-4">
@@ -50,6 +105,20 @@ export default function FXServerTab({
 						<SelectItem value="off">Off</SelectItem>
 					</SelectContent>
 				</Select>
+			</SettingRow>
+
+			<SettingRow
+				label="Startup Arguments"
+			>
+				<StartupArgumentsField
+					disabled={disabled}
+					value={startupArguments}
+					onChange={(value) => {
+						if (value === startupArguments) return;
+
+						onChange('fxserver.startupArguments', value);
+					}}
+				/>
 			</SettingRow>
 
 			<Separator />

--- a/apps/webpanel/src/pages/settings/tabs/fxserver.tsx
+++ b/apps/webpanel/src/pages/settings/tabs/fxserver.tsx
@@ -11,28 +11,8 @@ import type { SettingsTabProps } from '@/types/settings';
 import { Separator } from '@fxmanager/ui/components/separator';
 import { Input } from '@fxmanager/ui/components/input';
 import { Field, FieldDescription } from '@fxmanager/ui/components/field';
+import { validateStartupArguments } from '@fxmanager/shared/utils';
 import { useState } from 'react';
-
-const RESTRICTED_PATTERNS = [
-	/^\+set\s+onesync\b/i,
-	/^\+set\s+resource-api-token\b/i,
-	/^\+set\s+api-port\b/i,
-	/^\+(ensure|start|stop|restart)\s+fxManager\b/i,
-
-	/^\+add_convar_permission\s+\S+\s+\S+\s+resource-api-token\b/i,
-	/^\+add_convar_permission\s+\S+\s+\S+\s+api-port\b/i,
-];
-
-function checkStartupArguments(value: string) {
-	if (!value) return '';
-
-	const args = value.match(/(?:\+|--)\S+(?:\s+(?!(?:\+|--))\S+)*/g) ?? [];
-	const restricted = args.find((arg) => RESTRICTED_PATTERNS.some((patt) => patt.test(arg)));
-
-	if (!restricted) return '';
-
-	return `"${restricted}" is not allowed here.`;
-}
 
 function blur(event: React.KeyboardEvent<HTMLInputElement>) {
 	if (event.key !== 'Enter') return;
@@ -58,12 +38,14 @@ function StartupArgumentsField({
 				placeholder={'+exec server.cfg'}
 				onBlur={(event) => {
 					const value = event.currentTarget.value.trim();
-					const validationError = checkStartupArguments(value);
+					const validation = validateStartupArguments(value);
 
-					setError(validationError);
+					if (validation.valid !== true) {
+						setError(`"${validation.argument}" is not allowed here.`);
+						return;
+					}
 
-					if (validationError) return;
-
+					setError('');
 					onChange(value);
 				}}
 				onKeyDown={blur}

--- a/apps/webpanel/src/pages/settings/tabs/fxserver.tsx
+++ b/apps/webpanel/src/pages/settings/tabs/fxserver.tsx
@@ -107,9 +107,7 @@ export default function FXServerTab({
 				</Select>
 			</SettingRow>
 
-			<SettingRow
-				label="Startup Arguments"
-			>
+			<SettingRow label="Startup Arguments">
 				<StartupArgumentsField
 					disabled={disabled}
 					value={startupArguments}

--- a/apps/webpanel/src/pages/settings/tabs/fxserver.tsx
+++ b/apps/webpanel/src/pages/settings/tabs/fxserver.tsx
@@ -13,19 +13,22 @@ import { Input } from '@fxmanager/ui/components/input';
 import { Field, FieldDescription } from '@fxmanager/ui/components/field';
 import { useState } from 'react';
 
-const RESTRICTED_ARGS = [
-	'+set onesync',
-	'+set resource-api-token',
-	'+set api-port',
-	'+ensure fxManager',
-	'+add_convar_permission fxManager read resource-api-token',
-	'+add_convar_permission fxManager read api-port',
+const RESTRICTED_PATTERNS = [
+	/^\+set\s+onesync\b/i,
+	/^\+set\s+resource-api-token\b/i,
+	/^\+set\s+api-port\b/i,
+	/^\+(ensure|start|stop|restart)\s+fxManager\b/i,
+
+	/^\+add_convar_permission\s+\S+\s+\S+\s+resource-api-token\b/i,
+	/^\+add_convar_permission\s+\S+\s+\S+\s+api-port\b/i,
 ];
 
-function checkStartupArguments(args: string) {
-	if (!args) return '';
+function checkStartupArguments(value: string) {
+	if (!value) return '';
 
-	const restricted = RESTRICTED_ARGS.find((arg) => args.includes(arg));
+	const args = value.match(/(?:\+|--)\S+(?:\s+(?!(?:\+|--))\S+)*/g) ?? [];
+	const restricted = args.find((arg) => RESTRICTED_PATTERNS.some((patt) => patt.test(arg)));
+
 	if (!restricted) return '';
 
 	return `"${restricted}" is not allowed here.`;

--- a/packages/shared/src/constants/settings.ts
+++ b/packages/shared/src/constants/settings.ts
@@ -2,7 +2,7 @@ import type { SettingsKey, SettingsKeysByScope } from '../types';
 
 export const SETTINGS_SCOPES = {
 	general: [],
-	fxserver: ['onesync', 'executablePath', 'serverDataPath', 'serverConfigPath'],
+	fxserver: ['onesync', 'startupArguments', 'executablePath', 'serverDataPath', 'serverConfigPath'],
 	whitelist: ['mode', 'discordBotToken', 'discordGuildId', 'discordRoleIds'],
 	restarts: ['enabled', 'times'],
 } as const;
@@ -29,6 +29,7 @@ export const SETTINGS_SENSITIVE_KEYS: SettingsKey[] = [
 ];
 
 export const SETTINGS_MASTER_ONLY_KEYS: SettingsKey[] = [
+	'fxserver.startupArguments',
 	'fxserver.executablePath',
 	'fxserver.serverDataPath',
 	'fxserver.serverConfigPath',

--- a/packages/shared/src/constants/settings.ts
+++ b/packages/shared/src/constants/settings.ts
@@ -2,7 +2,13 @@ import type { SettingsKey, SettingsKeysByScope } from '../types';
 
 export const SETTINGS_SCOPES = {
 	general: [],
-	fxserver: ['onesync', 'startupArguments', 'executablePath', 'serverDataPath', 'serverConfigPath'],
+	fxserver: [
+		'onesync',
+		'startupArguments',
+		'executablePath',
+		'serverDataPath',
+		'serverConfigPath',
+	],
 	whitelist: ['mode', 'discordBotToken', 'discordGuildId', 'discordRoleIds'],
 	restarts: ['enabled', 'times'],
 } as const;

--- a/packages/shared/src/constants/settings.ts
+++ b/packages/shared/src/constants/settings.ts
@@ -40,3 +40,16 @@ export const SETTINGS_MASTER_ONLY_KEYS: SettingsKey[] = [
 	'fxserver.serverDataPath',
 	'fxserver.serverConfigPath',
 ];
+
+export const RESTRICTED_STARTUP_ARGUMENTS: RegExp[] = [
+	/^\+set\s+onesync\b/i,
+	/^\+set\s+resource-api-token\b/i,
+	/^\+set\s+api-port\b/i,
+	/^\+set\s+citizen-dir\b/i,
+	/^\+(ensure|start|stop|restart)\s+fxManager\b/i,
+
+	/^\+add_convar_permission\s+\S+\s+\S+\s+resource-api-token\b/i,
+	/^\+add_convar_permission\s+\S+\s+\S+\s+api-port\b/i,
+
+	/^--library-path\s+\S+/i,
+];

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './group-slug';
 export * from './permissions';
 export * from './resource-name';
 export * from './settings-access';
+export * from './startup-arguments';

--- a/packages/shared/src/utils/startup-arguments.test.ts
+++ b/packages/shared/src/utils/startup-arguments.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'bun:test';
+import { validateStartupArguments } from './startup-arguments';
+
+describe('validateStartupArguments()', () => {
+	it('should return true for valid arguments', () => {
+		expect(validateStartupArguments('+svgui --trace-warnings')).toEqual({
+			valid: true,
+		});
+		expect(validateStartupArguments('+exec somecfg.cfg')).toEqual({
+			valid: true,
+		});
+	});
+
+	it('should return the first restricted value for invalid arguments', () => {
+		expect(
+			validateStartupArguments('+exec somecfg.cfg +set onesync on'),
+		).toEqual({ valid: false, argument: '+set onesync on' });
+		expect(
+			validateStartupArguments('+stop fxManager +set api-port 40120'),
+		).toEqual({ valid: false, argument: '+stop fxManager' });
+		expect(
+			validateStartupArguments('--library-path /home/user/somefolder'),
+		).toEqual({
+			valid: false,
+			argument: '--library-path /home/user/somefolder',
+		});
+	});
+});

--- a/packages/shared/src/utils/startup-arguments.ts
+++ b/packages/shared/src/utils/startup-arguments.ts
@@ -1,0 +1,23 @@
+import { RESTRICTED_STARTUP_ARGUMENTS } from '../constants';
+
+export type ValidationResult =
+	| { valid: true }
+	| { valid: false; argument: string };
+
+/**
+ * Validates the given string for restricted startup arguments and, if invalid, returns the first invalid argument.
+ * @param value String of arguments to validate.
+ * @returns `true` if valid, otherwise the first invalid argument.
+ */
+export function validateStartupArguments(value: string): ValidationResult {
+	if (!value) return { valid: true };
+
+	const args = value.match(/(?:\+|--)\S+(?:\s+(?!(?:\+|--))\S+)*/g) ?? [];
+	const restricted = args.find((arg) =>
+		RESTRICTED_STARTUP_ARGUMENTS.some((patt) => patt.test(arg)),
+	);
+
+	if (!restricted) return { valid: true };
+
+	return { valid: false, argument: restricted };
+}


### PR DESCRIPTION
## Description

Adds the option to specify extra startup arguments for FXServer in the settings page. It also includes a validation system which prevents users from adding arguments already specified internally by the manager.

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [x] Builds & runs on Windows
- [ ] Builds & runs on Linux
