### PR TITLE
Fix: auth cookie being ignored

### DIFF
--- a/apps/core/src/routes/api/auth.ts
+++ b/apps/core/src/routes/api/auth.ts
@@ -2,7 +2,7 @@ import { Type, type Static } from '@sinclair/typebox';
 import type { FastifyPluginAsync } from 'fastify';
 import { repo } from '@fxmanager/database';
 
-import { COOKIE_NAME, isProduction } from '../../common/utils';
+import { COOKIE_NAME } from '../../common/utils';
 import { loginRateLimiter } from '../../modules/auth/rate-limiter';
 import type { RouteModule } from '../../types';
 
@@ -44,7 +44,7 @@ const AuthEndpoints: FastifyPluginAsync = async (fastify) => {
 			return reply
 				.setCookie(COOKIE_NAME, session.id, {
 					httpOnly: true,
-					secure: isProduction,
+					secure: request.protocol === 'https',
 					sameSite: 'lax',
 					path: '/',
 					maxAge: 60 * 60 * 24 * 7,


### PR DESCRIPTION
## Description

Whilst running the built application, the authentication cookie is "hardcoded" as being **only** for secure connections, meaning that any connection using `http` would fail as the cookie was not being sent.
This resolves it by allowing both http & https by varying the `secure` parameter depending on the used protocol.

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [x] Builds & runs on Windows
- [ ] Builds & runs on Linux

---

## Additional Notes

<!--
	Any extra details you wish to share, i.e.:
	* Unable to test on linux -> state why for context
	* Request feedback
	* Explain why the PR is listed as a Draft
	* List todo steps requiring discussion
-->
