### PR TITLE
Fix: leaving page alert on setup when finishing

### DIFF
--- a/apps/webpanel/src/pages/setup/index.tsx
+++ b/apps/webpanel/src/pages/setup/index.tsx
@@ -100,7 +100,6 @@ export function SetupApp() {
 
 	useEffect(() => {
 		const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-			console.log('beforeunload', step, isExitingRef.current);
 			if (isExitingRef.current) {
 				return;
 			}

--- a/apps/webpanel/src/pages/setup/index.tsx
+++ b/apps/webpanel/src/pages/setup/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Server } from 'lucide-react';
 import { cn } from '@fxmanager/ui/lib/utils';
 
@@ -23,9 +23,8 @@ export function SetupApp() {
 		resourcePath: '',
 		adminGroups: [],
 	});
-
-	const [isExiting, setIsExiting] = useState(false);
 	const [loading, setLoading] = useState(false);
+	const isExitingRef = useRef(false);
 
 	function setError(message: string) {
 		toast.error('An error occured', {
@@ -93,15 +92,16 @@ export function SetupApp() {
 	}
 
 	function handleExit() {
-		setIsExiting(true);
+		isExitingRef.current = true;
 		setTimeout(() => {
 			window.location.href = '/';
-		}, 0);
+		}, 10);
 	}
 
 	useEffect(() => {
 		const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-			if (isExiting && step === 'import') {
+			console.log('beforeunload', step, isExitingRef.current);
+			if (isExitingRef.current) {
 				return;
 			}
 			event.preventDefault();


### PR DESCRIPTION
## Description

The commit ( 2360b768f94e95cea47fe9d0d1fc56a0c673d73e ) introduced showing the "leaving page alert" when the page got refreshed or when leaving.

This used a state to define if it should skip it or not, leading to it not being skipped because it was not a dependency of the effect, using a ref avoids needing to trigger a useless re-render of the page for it.

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [x] Builds & runs on Windows
- [ ] Builds & runs on Linux

---

## Additional Notes

<!--
	Any extra details you wish to share, i.e.:
	* Unable to test on linux -> state why for context
	* Request feedback
	* Explain why the PR is listed as a Draft
	* List todo steps requiring discussion
-->
