### PR TITLE
Feat: fxserver paths validation

### DIFF
--- a/apps/core/src/common/utils.ts
+++ b/apps/core/src/common/utils.ts
@@ -1,6 +1,7 @@
 import os from 'os';
 import { randomBytes } from 'node:crypto';
 import { repo } from '@fxmanager/database';
+import { access } from 'node:fs/promises';
 
 export const isProduction = process.env.NODE_ENV === 'production';
 export const COOKIE_NAME = 'fxm_session';
@@ -36,4 +37,13 @@ export function getIp(): string {
 		}
 	}
 	return '127.0.0.1';
+}
+
+export async function fileExists(target: string): Promise<boolean> {
+	try {
+		await access(target);
+		return true;
+	} catch {
+		return false;
+	}
 }

--- a/apps/core/src/modules/config/manager.test.ts
+++ b/apps/core/src/modules/config/manager.test.ts
@@ -1,5 +1,6 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: explicit any allows testing hidden state properties & mocking frames */
-import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import path from 'node:path';
 
 const mockGetMultiple = mock<() => Record<string, unknown>>(() => ({}));
 const mockAll = mock<() => Array<{ key: string; value: any }>>(() => []);
@@ -17,10 +18,33 @@ mock.module('@fxmanager/database', () => ({
 	},
 }));
 
+const fileSystem = new Map<string, 'file' | 'dir'>();
+const mockStat = mock(async (targetPath: string) => {
+	const normalizedPath = path.normalize(targetPath);
+	const type = fileSystem.get(normalizedPath);
+
+	if (!type) throw new Error(`ENOENT: no such file or directory, stat '${normalizedPath}'`);
+
+	return {
+		isDirectory: () => type === 'dir',
+		isFile: () => type === 'file',
+	};
+});
+
+mock.module('node:fs/promises', () => ({
+	stat: mockStat,
+}));
+
 import { ConfigManager } from './manager';
 
 describe('ConfigManager', () => {
 	let originalEnv: typeof process.env;
+	let originalPlatform: NodeJS.Platform;
+
+	// Helper to override OS platform
+	const setPlatform = (platform: NodeJS.Platform) => {
+		Object.defineProperty(process, 'platform', { value: platform });
+	};
 
 	beforeEach(() => {
 		originalEnv = { ...process.env };
@@ -31,11 +55,16 @@ describe('ConfigManager', () => {
 		delete process.env.PANEL_PORT;
 		delete process.env.COOKIE_SECRET;
 
+		originalPlatform = process.platform;
+		fileSystem.clear();
+		mockStat.mockClear();
+
 		(ConfigManager as any).instance = null;
 	});
 
 	afterEach(() => {
 		process.env = originalEnv;
+		Object.defineProperty(process, 'platform', { value: originalPlatform });
 		(ConfigManager as any).instance = null;
 	});
 
@@ -176,6 +205,207 @@ describe('ConfigManager', () => {
 			expect(allValues.customVariable).toBe('hello-world');
 			expect(allValues.onesync).toBe('off');
 			expect(allValues.webServerPort).toBe(8080);
+		});
+	});
+
+	describe('validateExecutablePath()', () => {
+		it('auto-detects Windows FXServer.exe inside a valid directory', async () => {
+			setPlatform('win32');
+			const dirPath = path.join(process.cwd(), 'fxserver-folder');
+			const exePath = path.join(dirPath, 'FXServer.exe');
+
+			fileSystem.set(dirPath, 'dir');
+			fileSystem.set(exePath, 'file');
+
+			const config = ConfigManager.getInstance();
+			const res = await config.validateExecutablePath(dirPath);
+			expect(res.valid).toBe(true);
+			expect(res.path).toBe(exePath);
+		});
+
+		it('auto-detects Linux fxserver inside a valid directory', async () => {
+			setPlatform('linux');
+			const dirPath = path.join(process.cwd(), 'fxserver-folder');
+			const exePath = path.join(dirPath, 'fxserver');
+
+			fileSystem.set(dirPath, 'dir');
+			fileSystem.set(exePath, 'file');
+
+			const config = ConfigManager.getInstance();
+			const res = await config.validateExecutablePath(dirPath);
+			expect(res.valid).toBe(true);
+			expect(res.path).toBe(exePath);
+		});
+
+		it('validates a direct file path (Case-Insensitive on Windows)', async () => {
+			setPlatform('win32');
+			const exePath = path.join(process.cwd(), 'fXseRver.eXe');
+			fileSystem.set(exePath, 'file');
+
+			const config = ConfigManager.getInstance();
+			const res = await config.validateExecutablePath(exePath);
+			expect(res.valid).toBe(true);
+			expect(res.path).toBe(exePath);
+		});
+
+		it('rejects invalid executables', async () => {
+			setPlatform('win32');
+			const badExePath = path.join(process.cwd(), 'random.exe');
+			fileSystem.set(badExePath, 'file');
+
+			const config = ConfigManager.getInstance();
+			const res = await config.validateExecutablePath(badExePath);
+			expect(res.valid).toBe(false);
+			expect(res.path).toBe(badExePath);
+		});
+
+		it('handles missing paths gracefully', async () => {
+			const config = ConfigManager.getInstance();
+			const res = await config.validateExecutablePath('invalid/path');
+			expect(res.valid).toBe(false);
+		});
+	});
+
+	describe('validateDataPath()', () => {
+		it('validates an existing directory', async () => {
+			const dataPath = path.join(process.cwd(), 'server-data');
+			fileSystem.set(dataPath, 'dir');
+
+			const config = ConfigManager.getInstance();
+			const res = await config.validateDataPath(dataPath);
+			expect(res.valid).toBe(true);
+			expect(res.path).toBe(dataPath);
+		});
+
+		it('rejects if the path is a file, not a directory', async () => {
+			const dataPath = path.join(process.cwd(), 'server-data');
+			fileSystem.set(dataPath, 'file');
+
+			const config = ConfigManager.getInstance();
+			const res = await config.validateDataPath(dataPath);
+			expect(res.valid).toBe(false);
+		});
+
+		it('resolves relative paths to cwd', async () => {
+			const relativePath = 'my-data';
+			const expectedAbsPath = path.join(process.cwd(), relativePath);
+			fileSystem.set(expectedAbsPath, 'dir');
+
+			const config = ConfigManager.getInstance();
+			const res = await config.validateDataPath(relativePath);
+			expect(res.valid).toBe(true);
+			expect(res.path).toBe(expectedAbsPath);
+		});
+	});
+
+	describe('validateConfigPath()', () => {
+		it('validates an absolute config path', async () => {
+			const cfgPath = path.resolve('/absolute/path/server.cfg');
+			fileSystem.set(cfgPath, 'file');
+
+			const config = ConfigManager.getInstance();
+			const res = await config.validateConfigPath(cfgPath);
+			expect(res.valid).toBe(true);
+			expect(res.path).toBe(cfgPath);
+		});
+
+		it('uses providedDataPath for relative config files', async () => {
+			const providedDataPath = path.resolve('/custom/data/path');
+			const cfgName = 'server.cfg';
+			const expectedAbsPath = path.join(providedDataPath, cfgName);
+
+			fileSystem.set(expectedAbsPath, 'file');
+
+			const config = ConfigManager.getInstance();
+			const res = await config.validateConfigPath(cfgName, providedDataPath);
+			expect(res.valid).toBe(true);
+			expect(res.path).toBe(expectedAbsPath);
+		});
+
+		it('falls back to config manager values if no data path is provided', async () => {
+			const defaultDataPath = path.resolve('/default/data/path');
+			const cfgName = 'server.cfg';
+			const expectedAbsPath = path.join(defaultDataPath, cfgName);
+
+			const config = ConfigManager.getInstance();
+			spyOn(config, 'getFxServerValues').mockReturnValue({
+				serverDataPath: defaultDataPath,
+				serverConfigFile: cfgName,
+			} as any);
+
+			fileSystem.set(expectedAbsPath, 'file');
+
+			const res = await config.validateConfigPath(cfgName);
+			expect(res.valid).toBe(true);
+			expect(res.path).toBe(expectedAbsPath);
+		});
+
+		it('fails if the config path is a directory', async () => {
+			const cfgName = 'server.cfg';
+			const expectedAbsPath = path.join(process.cwd(), cfgName);
+
+			const config = ConfigManager.getInstance();
+			spyOn(config, 'getFxServerValues').mockReturnValue({
+				serverDataPath: process.cwd(),
+			} as any);
+
+			fileSystem.set(expectedAbsPath, 'dir');
+
+			const res = await config.validateConfigPath(cfgName);
+			expect(res.valid).toBe(false);
+		});
+	});
+
+	describe('checkFXServerPaths() (Integration)', () => {
+		it('returns fully valid when all paths are correct', async () => {
+			setPlatform('linux');
+			const inputExe = 'server-bin';
+			const inputData = 'server-data';
+
+			const expectedExe = path.join(process.cwd(), inputExe, 'fxserver');
+			const expectedData = path.join(process.cwd(), inputData);
+			const expectedCfg = path.join(expectedData, 'server.cfg');
+
+			fileSystem.set(path.join(process.cwd(), inputExe), 'dir');
+			fileSystem.set(expectedExe, 'file');
+			fileSystem.set(expectedData, 'dir');
+			fileSystem.set(expectedCfg, 'file');
+
+			const config = ConfigManager.getInstance();
+			spyOn(config, 'getFxServerValues').mockReturnValue({
+				serverConfigFile: 'server.cfg',
+			} as any);
+
+			const res = await config.checkFXServerPaths(inputExe, inputData);
+
+			expect(res.exists.executable).toBe(true);
+			expect(res.exists.serverdata).toBe(true);
+			expect(res.exists.cfg).toBe(true);
+
+			expect(res.files.executable).toBe(expectedExe);
+			expect(res.files.serverdata).toBe(expectedData);
+			expect(res.files.cfg).toBe(expectedCfg);
+		});
+
+		it('accurately reports partial failures', async () => {
+			setPlatform('win32');
+			const inputExe = 'FXServer.exe';
+			const inputData = 'server-data';
+
+			const expectedExe = path.join(process.cwd(), inputExe);
+
+			fileSystem.set(expectedExe, 'file');
+
+			const config = ConfigManager.getInstance();
+			spyOn(config, 'getFxServerValues').mockReturnValue({
+				serverConfigFile: 'server.cfg',
+			} as any);
+
+			const res = await config.checkFXServerPaths(inputExe, inputData);
+
+			expect(res.exists.executable).toBe(true);
+			expect(res.exists.serverdata).toBe(false);
+			expect(res.exists.cfg).toBe(false);
 		});
 	});
 });

--- a/apps/core/src/modules/config/manager.test.ts
+++ b/apps/core/src/modules/config/manager.test.ts
@@ -1,5 +1,13 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: explicit any allows testing hidden state properties & mocking frames */
-import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from 'bun:test';
 import path from 'node:path';
 
 const mockGetMultiple = mock<() => Record<string, unknown>>(() => ({}));
@@ -23,7 +31,10 @@ const mockStat = mock(async (targetPath: string) => {
 	const normalizedPath = path.normalize(targetPath);
 	const type = fileSystem.get(normalizedPath);
 
-	if (!type) throw new Error(`ENOENT: no such file or directory, stat '${normalizedPath}'`);
+	if (!type)
+		throw new Error(
+			`ENOENT: no such file or directory, stat '${normalizedPath}'`,
+		);
 
 	return {
 		isDirectory: () => type === 'dir',

--- a/apps/core/src/modules/config/manager.ts
+++ b/apps/core/src/modules/config/manager.ts
@@ -1,11 +1,14 @@
+import crypto from 'node:crypto';
+import path from 'node:path';
+import { stat } from 'node:fs/promises';
 import { repo } from '@fxmanager/database';
 import type {
 	CoreConfig,
 	PlatformOS,
 	ServerConfig,
 } from '@fxmanager/shared/types';
-import crypto from 'node:crypto';
 import { resolveAutostartEnabled } from '../process/autostart';
+import { cwd } from 'node:process';
 
 type CoreSettings = CoreConfig &
 	ServerConfig & {
@@ -120,6 +123,123 @@ export class ConfigManager {
 			...this.fxServerValues,
 			...persistent,
 			...this.systemValues, // System values should override everything else
+		};
+	}
+
+	async validateExecutablePath(
+		executableInput: string,
+	): Promise<{ valid: boolean; path: string }> {
+		const initialPath = path.isAbsolute(executableInput)
+			? executableInput
+			: path.join(cwd(), executableInput);
+
+		let finalPath = initialPath;
+		let found = false;
+
+		try {
+			const execStats = await stat(initialPath);
+
+			if (execStats.isDirectory()) {
+				const validNames =
+					process.platform === 'win32'
+						? ['FXServer.exe']
+						: ['fxserver', 'FXServer'];
+
+				for (const name of validNames) {
+					const testPath = path.join(initialPath, name);
+					try {
+						const testStats = await stat(testPath);
+						if (testStats.isFile()) {
+							finalPath = testPath;
+							found = true;
+							break;
+						}
+					} catch {}
+				}
+			} else if (execStats.isFile()) {
+				const fileName = path.basename(initialPath);
+				let isValid = false;
+
+				if (process.platform === 'win32') {
+					isValid = 'fxserver.exe' === fileName.toLowerCase();
+				} else {
+					const validLinuxNames = ['fxserver', 'FXServer'];
+					isValid = validLinuxNames.includes(fileName);
+				}
+
+				if (isValid) found = true;
+			}
+		} catch {
+			found = false;
+		}
+
+		return { valid: found, path: finalPath };
+	}
+
+	async validateDataPath(
+		dataInput: string,
+	): Promise<{ valid: boolean; path: string }> {
+		const dataPath = path.isAbsolute(dataInput)
+			? dataInput
+			: path.join(cwd(), dataInput);
+
+		let valid = false;
+		try {
+			const stats = await stat(dataPath);
+			valid = stats.isDirectory();
+		} catch {
+			valid = false;
+		}
+
+		return { valid, path: dataPath };
+	}
+
+	async validateConfigPath(
+		configInput: string,
+		providedDataPath?: string,
+	): Promise<{ valid: boolean; path: string }> {
+		const dataPath =
+			providedDataPath || this.getFxServerValues().serverDataPath;
+
+		const cfgPath = path.isAbsolute(configInput)
+			? configInput
+			: path.join(dataPath, configInput);
+
+		let valid = false;
+		try {
+			const stats = await stat(cfgPath);
+			valid = stats.isFile();
+		} catch {
+			valid = false;
+		}
+
+		return { valid, path: cfgPath };
+	}
+
+	async checkFXServerPaths(
+		executableInput: string,
+		serverDataInput: string,
+	): Promise<{
+		files: { executable: string; serverdata: string; cfg: string };
+		exists: { executable: boolean; serverdata: boolean; cfg: boolean };
+	}> {
+		const execResult = await this.validateExecutablePath(executableInput);
+		const dataResult = await this.validateDataPath(serverDataInput);
+
+		const cfgInput = this.getFxServerValues().serverConfigFile;
+		const cfgResult = await this.validateConfigPath(cfgInput, dataResult.path);
+
+		return {
+			files: {
+				executable: execResult.path,
+				serverdata: dataResult.path,
+				cfg: cfgResult.path,
+			},
+			exists: {
+				executable: execResult.valid,
+				serverdata: dataResult.valid,
+				cfg: cfgResult.valid,
+			},
 		};
 	}
 }

--- a/apps/core/src/modules/config/manager.ts
+++ b/apps/core/src/modules/config/manager.ts
@@ -142,7 +142,9 @@ export class ConfigManager {
 			if (execStats.isDirectory()) {
 				const validNames =
 					process.platform === 'win32'
+						// cover both as a sanity check
 						? ['fxserver.exe', 'FXServer.exe']
+						// should only be FXServer, but just in case we do both
 						: ['fxserver', 'FXServer'];
 
 				for (const name of validNames) {
@@ -160,10 +162,12 @@ export class ConfigManager {
 				const fileName = path.basename(initialPath);
 				const validNames =
 					process.platform === 'win32'
-						? ['fxserver.exe', 'FXServer.exe']
-						: ['fxserver', 'FXServer'];
+						? /^fxserver\.exe$/i
+						: /^(fxserver|FXServer)$/;
 
-				if (validNames.includes(fileName)) found = true;
+		    if (validNames.test(fileName)) {
+	        found = true;
+		    }
 			}
 		} catch {
 			found = false;

--- a/apps/core/src/modules/config/manager.ts
+++ b/apps/core/src/modules/config/manager.ts
@@ -142,7 +142,7 @@ export class ConfigManager {
 			if (execStats.isDirectory()) {
 				const validNames =
 					process.platform === 'win32'
-						? ['FXServer.exe']
+						? ['fxserver.exe', 'FXServer.exe']
 						: ['fxserver', 'FXServer'];
 
 				for (const name of validNames) {
@@ -158,16 +158,12 @@ export class ConfigManager {
 				}
 			} else if (execStats.isFile()) {
 				const fileName = path.basename(initialPath);
-				let isValid = false;
+				const validNames =
+					process.platform === 'win32'
+						? ['fxserver.exe', 'FXServer.exe']
+						: ['fxserver', 'FXServer'];
 
-				if (process.platform === 'win32') {
-					isValid = 'fxserver.exe' === fileName.toLowerCase();
-				} else {
-					const validLinuxNames = ['fxserver', 'FXServer'];
-					isValid = validLinuxNames.includes(fileName);
-				}
-
-				if (isValid) found = true;
+				if (validNames.includes(fileName)) found = true;
 			}
 		} catch {
 			found = false;
@@ -208,7 +204,8 @@ export class ConfigManager {
 		let valid = false;
 		try {
 			const stats = await stat(cfgPath);
-			valid = stats.isFile();
+			const isCfg = path.extname(cfgPath) === '.cfg';
+			valid = stats.isFile() && isCfg;
 		} catch {
 			valid = false;
 		}

--- a/apps/core/src/routes/api/settings/index.ts
+++ b/apps/core/src/routes/api/settings/index.ts
@@ -21,6 +21,7 @@ import {
 } from '@fxmanager/shared/constants';
 import { repo } from '@fxmanager/database';
 import { restartScheduler } from '../../../modules/schedule/manager';
+import { ConfigManager } from '../../../modules/config/manager';
 
 interface HookResult {
 	valid: boolean;
@@ -28,9 +29,36 @@ interface HookResult {
 }
 
 const SETTINGS_HOOKS: Partial<
-	Record<SettingsKey, (value: string) => HookResult>
+	Record<SettingsKey, (value: string) => Promise<HookResult> | HookResult>
 > = {
 	'fxserver.startupArguments': validateStartupArguments,
+	'fxserver.executablePath': async (value: string) => {
+		const config = ConfigManager.getInstance();
+		const result = await config.validateExecutablePath(value);
+
+		return {
+			valid: result.valid,
+			correctedValue: result.path,
+		};
+	},
+	'fxserver.serverDataPath': async (value: string) => {
+		const config = ConfigManager.getInstance();
+		const result = await config.validateDataPath(value);
+
+		return {
+			valid: result.valid,
+			correctedValue: result.path,
+		};
+	},
+	'fxserver.serverConfigPath': async (value: string) => {
+		const config = ConfigManager.getInstance();
+		const result = await config.validateConfigPath(value);
+
+		return {
+			valid: result.valid,
+			correctedValue: result.path,
+		};
+	},
 };
 
 const SettingsEndpoints: RouteModule['handler'] = async (
@@ -96,15 +124,22 @@ const SettingsEndpoints: RouteModule['handler'] = async (
 		}
 
 		const hook = SETTINGS_HOOKS[key as SettingsKey];
-		if (hook && !hook(value).valid) {
+		const hookResult = hook && (await hook(value));
+		if (hookResult && !hookResult.valid) {
 			throw new Error('Invalid value');
 		}
 
-		repo.settings.set(key, value);
+		const newValue =
+			hookResult && hookResult?.correctedValue
+				? hookResult.correctedValue
+				: value;
+
+		repo.settings.set(key, newValue);
 
 		const logValue = SETTINGS_SENSITIVE_KEYS.includes(key as SettingsKey)
 			? 'REDACTED'
-			: value;
+			: newValue;
+
 		repo.audit.log({
 			adminId: admin.id,
 			action: 'settings.update',
@@ -113,7 +148,12 @@ const SettingsEndpoints: RouteModule['handler'] = async (
 
 		if (scope === 'restarts') restartScheduler.reload();
 
-		return { success: true, data: undefined };
+		return {
+			success: true,
+			data: hookResult?.correctedValue && {
+				correctedValue: hookResult.correctedValue,
+			},
+		};
 	});
 
 	fastify.register(AdminManagementModule.handler, {

--- a/apps/core/src/routes/api/setup.ts
+++ b/apps/core/src/routes/api/setup.ts
@@ -1,11 +1,10 @@
 import path from 'node:path';
-import { access } from 'node:fs/promises';
 import { Type, type Static } from '@sinclair/typebox';
 import type { FastifyPluginAsync } from 'fastify';
 import { repo } from '@fxmanager/database';
 import { UserPermissions } from '@fxmanager/shared/constants';
 import type { ApiResponse } from '@fxmanager/shared/types';
-import { COOKIE_NAME, isFxManagerSetup } from '../../common/utils';
+import { COOKIE_NAME, fileExists, isFxManagerSetup } from '../../common/utils';
 import { ConfigManager } from '../../modules/config/manager';
 import { setupTokenManager } from '../../modules/setup/token';
 import type { RouteModule } from '../../types';
@@ -15,15 +14,6 @@ interface DetectResult {
 	dataPath: string;
 	cfgPath: string;
 	found: { executable: boolean; dataPath: boolean; cfg: boolean };
-}
-
-async function fileExists(target: string): Promise<boolean> {
-	try {
-		await access(target);
-		return true;
-	} catch {
-		return false;
-	}
 }
 
 const AdminGroupSchema = Type.Object({
@@ -76,6 +66,39 @@ const SetupEndpoint: FastifyPluginAsync = async (fastify) => {
 				dataPath: cfg.serverDataPath,
 				cfgPath,
 				found: { executable, dataPath, cfg: cfgFound },
+			},
+		} satisfies ApiResponse<DetectResult>;
+	});
+
+	fastify.post('/checkfiles', async (request, reply) => {
+		if (isFxManagerSetup()) {
+			return reply.code(403).send({ success: false, error: 'Already set up' });
+		}
+
+		if (!setupTokenManager.validate(request.headers['x-setup-token'])) {
+			return reply
+				.code(401)
+				.send({ success: false, error: 'Invalid setup token' });
+		}
+
+		const body = request.body as { fxserverPath: string; dataPath: string };
+
+		const result = await ConfigManager.getInstance().checkFXServerPaths(
+			body.fxserverPath,
+			body.dataPath,
+		);
+
+		return {
+			success: true,
+			data: {
+				executable: result.files.executable,
+				dataPath: result.files.serverdata,
+				cfgPath: result.files.cfg,
+				found: {
+					executable: result.exists.executable,
+					dataPath: result.exists.serverdata,
+					cfg: result.exists.cfg,
+				},
 			},
 		} satisfies ApiResponse<DetectResult>;
 	});

--- a/apps/webpanel/src/pages/settings/index.tsx
+++ b/apps/webpanel/src/pages/settings/index.tsx
@@ -21,6 +21,7 @@ import WhitelistTab from './tabs/whitelist';
 import RestartsTab from './tabs/restarts';
 import { QueryService } from '@/lib/query';
 import type {
+	ApiError,
 	ApiResponse,
 	SettingsKey,
 	SettingsScope,
@@ -76,29 +77,26 @@ export default function SettingsPage() {
 	const [disabled, setDisabled] = useState(false);
 	const [cache, setCache] = useState<SettingsCache>({});
 
-	const loadTab = useCallback(
-		async (tab: string, useCache = true) => {
-			if (tab in cache && useCache) return;
+	const loadTab = useCallback(async (tab: string, useCache = true) => {
+		if (tab in cache && useCache) return;
 
-			setLoading(true);
+		setLoading(true);
 
-			try {
-				const response = await QueryService<ApiResponse<SettingsCache>>({
-					endpoint: `/settings/${tab}`,
-					method: 'GET',
-				});
+		try {
+			const response = await QueryService<ApiResponse<SettingsCache>>({
+				endpoint: `/settings/${tab}`,
+				method: 'GET',
+			});
 
-				if (response.success) {
-					setCache((prev) => ({ ...prev, [tab]: response.data }));
-				}
-			} catch {
-				toast.error('Failed to load settings.');
-			} finally {
-				setLoading(false);
+			if (response.success) {
+				setCache((prev) => ({ ...prev, [tab]: response.data }));
 			}
-		},
-		[cache],
-	);
+		} catch {
+			toast.error('Failed to load settings.');
+		} finally {
+			setLoading(false);
+		}
+	}, []);
 
 	async function updateSettings<S extends SettingsScope>(
 		scope: S,
@@ -118,7 +116,9 @@ export default function SettingsPage() {
 		setDisabled(true);
 
 		try {
-			const response = await QueryService<ApiResponse>({
+			const response = await QueryService<
+				ApiResponse<{ correctedValue?: string } | undefined>
+			>({
 				endpoint: `/settings/${scope}`,
 				method: 'POST',
 				body: { key, value },
@@ -132,9 +132,25 @@ export default function SettingsPage() {
 						[key]: previousValue,
 					},
 				}));
+			} else if (response.data?.correctedValue !== undefined) {
+				setCache((prev) => {
+					const currentScopeData = prev[scope] || {};
+					return {
+						...prev,
+						[scope]: {
+							...currentScopeData,
+							[key]: response.data?.correctedValue,
+						},
+					};
+				});
+
+				await loadTab(scope, false);
 			}
-		} catch {
-			toast.error(`Failed to update setting.`);
+		} catch (error) {
+			const err = error as ApiError;
+			toast.error(`Failed to update setting.`, {
+				description: err.message,
+			});
 
 			setCache((prev) => ({
 				...prev,

--- a/apps/webpanel/src/pages/settings/index.tsx
+++ b/apps/webpanel/src/pages/settings/index.tsx
@@ -190,8 +190,7 @@ export default function SettingsPage() {
 						</TabsTrigger>
 					))}
 				</TabsList>
-
-				<ScrollArea className="h-[calc(100vh-12rem)]">
+				<ScrollArea className="flex-1 min-h-0">
 					{TABS.map(({ value, label, description, component: Component }) => (
 						<TabsContent key={value} value={value}>
 							<Card>

--- a/apps/webpanel/src/pages/setup/ServerStep.tsx
+++ b/apps/webpanel/src/pages/setup/ServerStep.tsx
@@ -5,12 +5,21 @@ import {
 	CheckCircle2,
 	XCircle,
 	ScanSearch,
+	AlertTriangle,
 } from 'lucide-react';
 import { Label } from '@fxmanager/ui/components/label';
 import { Input } from '@fxmanager/ui/components/input';
 import { Button } from '@fxmanager/ui/components/button';
 import { Alert, AlertDescription } from '@fxmanager/ui/components/alert';
 import { Spinner } from '@fxmanager/ui/components/spinner';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@fxmanager/ui/components/dialog';
 import type { SetupFormData } from './types';
 import { getSetupToken } from './setup-token';
 
@@ -58,8 +67,15 @@ function DetectedPath({
 
 export function ServerStep({ formData, onChange, onNext }: ServerStepProps) {
 	const [detecting, setDetecting] = useState(false);
+	const [isChecking, setIsChecking] = useState(false);
 	const [detect, setDetect] = useState<DetectData | null>(null);
 	const [detectError, setDetectError] = useState<string | null>(null);
+
+	const [missingFiles, setMissingFiles] = useState<{
+		executable: boolean;
+		dataPath: boolean;
+		cfg: boolean;
+	} | null>(null);
 
 	const detectedOk =
 		!!detect && detect.found.executable && detect.found.dataPath;
@@ -95,6 +111,72 @@ export function ServerStep({ formData, onChange, onNext }: ServerStepProps) {
 		}
 	}
 
+	async function runCheck(): Promise<DetectData['found'] | null> {
+		setIsChecking(true);
+		setDetectError(null);
+		try {
+			const res = await fetch('/api/setup/checkfiles', {
+				method: 'POST',
+				credentials: 'include',
+				headers: {
+					'Content-Type': 'application/json',
+					'x-setup-token': getSetupToken(),
+				},
+				body: JSON.stringify({
+					fxserverPath: formData.fxserverPath,
+					dataPath: formData.resourcePath,
+				}),
+			});
+
+			const payload = (await res.json().catch(() => null)) as
+				| { success: true; data: DetectData }
+				| { success: false; error: string }
+				| null;
+
+			if (!res.ok || !payload?.success) {
+				throw new Error(
+					(payload && !payload.success && payload.error) ||
+						'File check failed.',
+				);
+			}
+
+			onChange('fxserverPath', payload.data.executable);
+			onChange('resourcePath', payload.data.dataPath);
+
+			return payload.data.found;
+		} catch (err) {
+			setDetectError((err as Error).message);
+			return null;
+		} finally {
+			setIsChecking(false);
+		}
+	}
+
+	async function handleNext() {
+		if (formData.serverSetupMethod === 'installer') {
+			if (detectedOk) onNext();
+			return;
+		}
+
+		if (!formData.fxserverPath || !formData.resourcePath) {
+			setDetectError('Please fill in both paths before continuing.');
+			return;
+		}
+
+		const foundStatus = await runCheck();
+
+		if (!foundStatus) return;
+
+		const allFilesExist =
+			foundStatus.executable && foundStatus.dataPath && foundStatus.cfg;
+
+		if (!allFilesExist) {
+			setMissingFiles(foundStatus);
+		} else {
+			onNext();
+		}
+	}
+
 	function selectManual() {
 		onChange('serverSetupMethod', 'manual');
 	}
@@ -105,144 +187,237 @@ export function ServerStep({ formData, onChange, onNext }: ServerStepProps) {
 	}
 
 	return (
-		<div className="flex flex-col gap-6 py-4 w-full">
-			<div className="space-y-1">
-				<h3 className="text-base font-semibold">
-					Instance Core Path Definitions
-				</h3>
-				<p className="text-xs text-muted-foreground">
-					Point fxManager at your FXServer binary and data folder — or let it
-					auto-detect a default Docker install.
-				</p>
-			</div>
-
-			<div className="flex items-center gap-2 bg-muted p-1 rounded-lg w-fit">
-				<Button
-					type="button"
-					variant={
-						formData.serverSetupMethod === 'manual' ? 'default' : 'ghost'
-					}
-					size="sm"
-					onClick={selectManual}
-				>
-					Local Directory Binding
-				</Button>
-				<Button
-					type="button"
-					variant={
-						formData.serverSetupMethod === 'installer' ? 'default' : 'ghost'
-					}
-					size="sm"
-					onClick={selectAutomatic}
-				>
-					Auto-detect (Docker)
-				</Button>
-			</div>
-
-			{formData.serverSetupMethod === 'manual' ? (
-				<div className="flex flex-col gap-4">
-					<div className="flex flex-col gap-1.5">
-						<Label htmlFor="fxserverPath">FXServer Absolute Path</Label>
-						<Input
-							id="fxserverPath"
-							type="text"
-							placeholder="/home/fxserver/alpine/opt/cfx/fxserver"
-							value={formData.fxserverPath}
-							onChange={(e) => onChange('fxserverPath', e.target.value)}
-							required
-						/>
-					</div>
-
-					<div className="flex flex-col gap-1.5">
-						<Label htmlFor="resourcePath">Data Resources Folder Path</Label>
-						<Input
-							id="resourcePath"
-							type="text"
-							placeholder="/home/fxserver/server-data/resources"
-							value={formData.resourcePath}
-							onChange={(e) => onChange('resourcePath', e.target.value)}
-							required
-						/>
-					</div>
+		<>
+			<div className="flex flex-col gap-6 py-4 w-full relative">
+				<div className="space-y-1">
+					<h3 className="text-base font-semibold">
+						Instance Core Path Definitions
+					</h3>
+					<p className="text-xs text-muted-foreground">
+						Point fxManager at your FXServer binary and data folder - or let it
+						auto-detect a default Docker install.
+					</p>
 				</div>
-			) : (
-				<div className="flex flex-col gap-4">
-					{detecting && (
-						<div className="flex items-center gap-2 text-sm text-muted-foreground">
-							<Spinner className="size-4" /> Scanning for an existing install...
+
+				<div className="flex items-center gap-2 bg-muted p-1 rounded-lg w-fit">
+					<Button
+						type="button"
+						variant={
+							formData.serverSetupMethod === 'manual' ? 'default' : 'ghost'
+						}
+						size="sm"
+						onClick={selectManual}
+					>
+						Local Directory Binding
+					</Button>
+					<Button
+						type="button"
+						variant={
+							formData.serverSetupMethod === 'installer' ? 'default' : 'ghost'
+						}
+						size="sm"
+						onClick={selectAutomatic}
+					>
+						Auto-detect (Docker)
+					</Button>
+				</div>
+
+				{formData.serverSetupMethod === 'manual' ? (
+					<div className="flex flex-col gap-4">
+						<div className="flex flex-col gap-1.5">
+							<Label htmlFor="fxserverPath">FXServer Absolute Path</Label>
+							<Input
+								id="fxserverPath"
+								type="text"
+								placeholder="/home/fxserver/alpine/opt/cfx/fxserver"
+								value={formData.fxserverPath}
+								onChange={(e) => onChange('fxserverPath', e.target.value)}
+								required
+							/>
+						</div>
+
+						<div className="flex flex-col gap-1.5">
+							<Label htmlFor="resourcePath">Data Resources Folder Path</Label>
+							<Input
+								id="resourcePath"
+								type="text"
+								placeholder="/home/fxserver/server-data"
+								value={formData.resourcePath}
+								onChange={(e) => onChange('resourcePath', e.target.value)}
+								required
+							/>
+						</div>
+
+						{detectError && (
+							<p className="text-sm text-destructive">{detectError}</p>
+						)}
+					</div>
+				) : (
+					<div className="flex flex-col gap-4">
+						{detecting && (
+							<div className="flex items-center gap-2 text-sm text-muted-foreground">
+								<Spinner className="size-4" /> Scanning for an existing
+								install...
+							</div>
+						)}
+
+						{!detecting && detect && (
+							<>
+								<div className="flex flex-col gap-3 rounded-lg border p-4">
+									<DetectedPath
+										label="FXServer binary"
+										value={detect.executable}
+										found={detect.found.executable}
+									/>
+									<DetectedPath
+										label="Data folder"
+										value={detect.dataPath}
+										found={detect.found.dataPath}
+									/>
+									<DetectedPath
+										label="server.cfg"
+										value={detect.cfgPath}
+										found={detect.found.cfg}
+									/>
+								</div>
+
+								{detectedOk ? (
+									<Alert>
+										<CheckCircle2 className="size-4 text-primary" />
+										<AlertDescription>
+											Detected your install — these paths will be used.
+										</AlertDescription>
+									</Alert>
+								) : (
+									<Alert>
+										<InfoIcon className="size-4 text-amber-500" />
+										<AlertDescription>
+											Couldn't find the default files. Switch to{' '}
+											<span className="font-medium text-foreground">
+												Local Directory Binding
+											</span>{' '}
+											to enter the paths manually.
+										</AlertDescription>
+									</Alert>
+								)}
+							</>
+						)}
+
+						{!detecting && detectError && (
+							<p className="text-sm text-destructive">{detectError}</p>
+						)}
+
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							className="w-fit gap-2"
+							disabled={detecting || isChecking}
+							onClick={runDetect}
+						>
+							<ScanSearch className="size-4" />
+							{detect || detectError ? 'Re-scan' : 'Scan'}
+						</Button>
+					</div>
+				)}
+
+				<div className="flex justify-end pt-4 border-t mt-2">
+					<Button
+						type="button"
+						className="gap-2 w-full md:w-auto px-5"
+						onClick={handleNext}
+						disabled={
+							(formData.serverSetupMethod === 'installer' && !detectedOk) ||
+							detecting ||
+							isChecking
+						}
+					>
+						{isChecking ? (
+							<>
+								<Spinner className="size-4" /> Checking Files...
+							</>
+						) : (
+							<>
+								Continue <ArrowRight className="size-4" />
+							</>
+						)}
+					</Button>
+				</div>
+			</div>
+
+			<Dialog
+				open={!!missingFiles}
+				onOpenChange={(isOpen) => !isOpen && setMissingFiles(null)}
+			>
+				<DialogContent className="max-w-md">
+					<DialogHeader>
+						<DialogTitle className="flex items-center gap-2">
+							<AlertTriangle className="size-5 text-amber-500" />
+							Missing Files Detected
+						</DialogTitle>
+						<DialogDescription>
+							We couldn't verify the following required components at the paths
+							you provided:
+						</DialogDescription>
+					</DialogHeader>
+
+					{missingFiles && (
+						<div className="flex flex-col gap-3 py-2">
+							{!missingFiles.executable && (
+								<div className="flex items-start gap-2 text-sm text-destructive bg-destructive/10 p-3 rounded-md">
+									<XCircle className="size-4 mt-0.5 shrink-0" />
+									<p>
+										<strong>FXServer Executable</strong> was not found. Please
+										ensure the path points directly to your FXServer binary or
+										folder.
+									</p>
+								</div>
+							)}
+							{!missingFiles.dataPath && (
+								<div className="flex items-start gap-2 text-sm text-destructive bg-destructive/10 p-3 rounded-md">
+									<XCircle className="size-4 mt-0.5 shrink-0" />
+									<p>
+										<strong>Data Folder</strong> could not be read or does not
+										exist.
+									</p>
+								</div>
+							)}
+							{!missingFiles.cfg && missingFiles.dataPath && (
+								<div className="flex items-start gap-2 text-sm text-amber-600 bg-amber-500/10 p-3 rounded-md dark:text-amber-500">
+									<InfoIcon className="size-4 mt-0.5 shrink-0" />
+									<p>
+										<strong>server.cfg</strong> was not found in the provided
+										server data path.
+									</p>
+								</div>
+							)}
+							{!missingFiles.cfg && !missingFiles.dataPath && (
+								<div className="flex items-start gap-2 text-sm text-destructive bg-destructive/10 p-3 rounded-md">
+									<XCircle className="size-4 mt-0.5 shrink-0" />
+									<p>
+										<strong>server.cfg</strong> could not be located because the
+										data folder is invalid.
+									</p>
+								</div>
+							)}
 						</div>
 					)}
 
-					{!detecting && detect && (
-						<>
-							<div className="flex flex-col gap-3 rounded-lg border p-4">
-								<DetectedPath
-									label="FXServer binary"
-									value={detect.executable}
-									found={detect.found.executable}
-								/>
-								<DetectedPath
-									label="Data folder"
-									value={detect.dataPath}
-									found={detect.found.dataPath}
-								/>
-								<DetectedPath
-									label="server.cfg"
-									value={detect.cfgPath}
-									found={detect.found.cfg}
-								/>
-							</div>
-
-							{detectedOk ? (
-								<Alert>
-									<CheckCircle2 className="size-4 text-primary" />
-									<AlertDescription>
-										Detected your install — these paths will be used.
-									</AlertDescription>
-								</Alert>
-							) : (
-								<Alert>
-									<InfoIcon className="size-4 text-amber-500" />
-									<AlertDescription>
-										Couldn't find the default files. Switch to{' '}
-										<span className="font-medium text-foreground">
-											Local Directory Binding
-										</span>{' '}
-										to enter the paths manually.
-									</AlertDescription>
-								</Alert>
-							)}
-						</>
-					)}
-
-					{!detecting && detectError && (
-						<p className="text-sm text-destructive">{detectError}</p>
-					)}
-
-					<Button
-						type="button"
-						variant="outline"
-						size="sm"
-						className="w-fit gap-2"
-						disabled={detecting}
-						onClick={runDetect}
-					>
-						<ScanSearch className="size-4" />
-						{detect || detectError ? 'Re-scan' : 'Scan'}
-					</Button>
-				</div>
-			)}
-
-			<div className="flex justify-end pt-4 border-t mt-2">
-				<Button
-					type="button"
-					className="gap-2 w-full md:w-auto px-5"
-					onClick={onNext}
-					disabled={formData.serverSetupMethod === 'installer' && !detectedOk}
-				>
-					Continue <ArrowRight className="size-4" />
-				</Button>
-			</div>
-		</div>
+					<DialogFooter className="mt-4 flex sm:justify-end gap-2">
+						<Button variant="outline" onClick={() => setMissingFiles(null)}>
+							Review Paths
+						</Button>
+						<Button
+							onClick={() => {
+								setMissingFiles(null);
+								onNext();
+							}}
+						>
+							Proceed Anyway
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</>
 	);
 }


### PR DESCRIPTION
## Description

Bouncing on #49 referring to "path completion", this PR introduces some validation on the various paths that are needed to run a server. It is implemented in the setup process as well as the server settings.

For the setup process:
* it sends the inputted data (allowing absolute & relative paths) once the continue button is pressed
* it will allow you to skip the checks if they fail (in case you will set it up after - not ideal anyways)

For the settings page (fxserver tab):
* uses the hooks to validate the values & checks that they return to existing directories & files

Other minor tweaks:
* added helper functions to ConfigManager to do these checks
* fixed settings page height not being responsive
* tweaked error toast in settings if the setting fails to set (includes the error message in the description)

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [x] Builds & runs on Windows
- [ ] Builds & runs on Linux

---

## Additional Notes

<details>
<summary>Images of the warning in the setup process</summary>

<img width="609" height="498" alt="image" src="https://github.com/user-attachments/assets/06258c64-262d-4601-8d3e-f057ec83bb34" />
<img width="590" height="459" alt="image" src="https://github.com/user-attachments/assets/90ef93f5-3f63-4d0f-9344-78cea34b18f9" />
<img width="577" height="443" alt="image" src="https://github.com/user-attachments/assets/e4ad446d-7d18-4d82-a443-95b184873841" />

</details>