### PR TITLE
Fix: server stuck on starting

### DIFF
--- a/apps/core/src/modules/process/manager.test.ts
+++ b/apps/core/src/modules/process/manager.test.ts
@@ -386,7 +386,7 @@ describe('ProcessManager', () => {
 		it('should bypass graceful shutdown and terminate immediately when forceCrash is true', async () => {
 			await processManager.start();
 
-			pushToStream(stdoutController, 'Authenticated with cfx.re Nucleus\n');
+			processManager.setFxServerReady();
 			await Bun.sleep(15);
 
 			const stopPromise = processManager.stop({ forceCrash: true });

--- a/apps/core/src/modules/process/manager.test.ts
+++ b/apps/core/src/modules/process/manager.test.ts
@@ -323,11 +323,10 @@ describe('ProcessManager', () => {
 	});
 
 	describe('Piped Output Streams & Line Parsing', () => {
-		it('should promote tracking context to running and load system resources when authentication patterns match', async () => {
+		it('should promote tracking context to running and load system resources when setFxServerReady is explicitly called', async () => {
 			await processManager.start();
 
-			pushToStream(stdoutController, 'Some random bootup message...\n');
-			pushToStream(stdoutController, 'Authenticated with cfx.re Nucleus\n');
+			processManager.setFxServerReady();
 
 			await Bun.sleep(15); // Extended sleep value to let the text decoder transform stream cycles settle
 
@@ -340,7 +339,7 @@ describe('ProcessManager', () => {
 		it('reads, parses, and stores the fxServer artifact build once the server is running', async () => {
 			await processManager.start();
 
-			pushToStream(stdoutController, 'Authenticated with cfx.re Nucleus\n');
+			processManager.setFxServerReady();
 			await Bun.sleep(15);
 
 			expect(processManager.getState().status).toBe('running');
@@ -406,7 +405,7 @@ describe('ProcessManager', () => {
 	describe('txAdmin serverShuttingDown compat', () => {
 		it('relays serverShuttingDown when stopping a running server, with the grace delay and author', async () => {
 			await processManager.start();
-			pushToStream(stdoutController, 'Authenticated with cfx.re Nucleus\n');
+			processManager.setFxServerReady();
 			await Bun.sleep(15);
 			expect(processManager.getState().status).toBe('running');
 
@@ -422,7 +421,7 @@ describe('ProcessManager', () => {
 
 		it('defaults the author to System when none is supplied', async () => {
 			await processManager.start();
-			pushToStream(stdoutController, 'Authenticated with cfx.re Nucleus\n');
+			processManager.setFxServerReady();
 			await Bun.sleep(15);
 
 			const stopPromise = processManager.stop();
@@ -446,7 +445,7 @@ describe('ProcessManager', () => {
 
 		it('relays serverShuttingDown once on the stop leg of a restart', async () => {
 			await processManager.start();
-			pushToStream(stdoutController, 'Authenticated with cfx.re Nucleus\n');
+			processManager.setFxServerReady();
 			await Bun.sleep(15);
 
 			const restartPromise = processManager.restart({ author: 'Maximus' });

--- a/apps/core/src/modules/process/manager.ts
+++ b/apps/core/src/modules/process/manager.ts
@@ -224,6 +224,12 @@ export class ProcessManager {
 		return this.state;
 	}
 
+	setFxServerReady() {
+		if (this.state.status !== 'starting') return;
+		this.setState('running');
+		this.clearStartupWatchdog();
+	}
+
 	injectConsoleLine(params: {
 		payload?: RawOutputLine;
 		process?: string;
@@ -473,12 +479,7 @@ export class ProcessManager {
 				} satisfies RawOutputLine;
 
 				if (this.state.status === 'starting') {
-					if (value.includes('Authenticated with cfx.re Nucleus')) {
-						this.clearStartupWatchdog();
-						this.setState('running');
-					} else {
-						this.armStartupWatchdog();
-					}
+					this.armStartupWatchdog();
 				}
 
 				console.log(value);

--- a/apps/core/src/routes/internal/index.ts
+++ b/apps/core/src/routes/internal/index.ts
@@ -1,6 +1,7 @@
 import PlayerModule from './players';
 import ResourceModule from './resources';
 import IngameModule from './ingame';
+import ServerModule from './server';
 import { requireLoopback } from '../../middleware/loopback';
 import type { RouteModule } from '../../types';
 
@@ -20,6 +21,11 @@ const internalRoutes: RouteModule['handler'] = async (fastify, options) => {
 	fastify.register(IngameModule.handler, {
 		...options,
 		prefix: IngameModule.prefix,
+	});
+
+	fastify.register(ServerModule.handler, {
+		...options,
+		prefix: ServerModule.prefix,
 	});
 };
 

--- a/apps/core/src/routes/internal/server.ts
+++ b/apps/core/src/routes/internal/server.ts
@@ -1,0 +1,18 @@
+import type { ResourceData } from '@fxmanager/shared/types';
+import { resourceAuth } from '../../middleware/resource';
+import type { RouteModule } from '../../types';
+
+const ServerEndpoints: RouteModule['handler'] = async (fastify, options) => {
+	const { pm } = options;
+
+	fastify.addHook('preHandler', resourceAuth);
+
+	fastify.post('/ready', () => {
+		pm.setFxServerReady();
+	});
+};
+
+export default {
+	prefix: '/server',
+	handler: ServerEndpoints,
+} satisfies RouteModule;

--- a/apps/resource/package.json
+++ b/apps/resource/package.json
@@ -1,39 +1,39 @@
 {
-  "name": "@fxmanager/resource",
-  "version": "0.3.0",
-  "license": "",
-  "description": "",
-  "type": "module",
-  "scripts": {
-    "web:dev": "cd web && vite dev",
-    "build": "bun scripts/build.js",
-    "deploy": "bun scripts/deploy.js",
-    "dev": "bun scripts/build.js --watch",
-    "format": "biome format --write",
-    "lint": "biome lint --write"
-  },
-  "devDependencies": {
-    "@citizenfx/client": "latest",
-    "@citizenfx/server": "latest",
-    "@communityox/fx-utils": "^0.0.4",
-    "@fxmanager/shared": "workspace:*",
-    "@jgoz/esbuild-plugin-typecheck": "^4.0.3",
-    "@types/node": "^22.13.9",
-    "@types/react": "^18.3.18",
-    "@types/react-dom": "^18.3.5",
-    "@vitejs/plugin-react": "^4.3.4",
-    "dotenv": "^17.4.2",
-    "esbuild": "^0.25.0",
-    "fs-extra": "^11.3.4",
-    "typescript": "^5.8.2",
-    "vite": "^5.4.14"
-  },
-  "dependencies": {
-    "@communityox/ox_lib": "latest",
-    "@nativewrappers/fivem": "latest",
-    "node-fetch": "^3.3.2",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "zod": "^4.3.6"
-  }
+	"name": "@fxmanager/resource",
+	"version": "0.3.0",
+	"license": "",
+	"description": "",
+	"type": "module",
+	"scripts": {
+		"web:dev": "cd web && vite dev",
+		"build": "bun scripts/build.js",
+		"deploy": "bun scripts/deploy.js",
+		"dev": "bun scripts/build.js --watch",
+		"format": "biome format --write",
+		"lint": "biome lint --write"
+	},
+	"devDependencies": {
+		"@citizenfx/client": "latest",
+		"@citizenfx/server": "latest",
+		"@communityox/fx-utils": "^0.0.4",
+		"@fxmanager/shared": "workspace:*",
+		"@jgoz/esbuild-plugin-typecheck": "^4.0.3",
+		"@types/node": "^22.13.9",
+		"@types/react": "^18.3.18",
+		"@types/react-dom": "^18.3.5",
+		"@vitejs/plugin-react": "^4.3.4",
+		"dotenv": "^17.4.2",
+		"esbuild": "^0.25.0",
+		"fs-extra": "^11.3.4",
+		"typescript": "^5.8.2",
+		"vite": "^5.4.14"
+	},
+	"dependencies": {
+		"@communityox/ox_lib": "latest",
+		"@nativewrappers/fivem": "latest",
+		"node-fetch": "^3.3.2",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1",
+		"zod": "^4.3.6"
+	}
 }

--- a/apps/resource/src/server/exports.ts
+++ b/apps/resource/src/server/exports.ts
@@ -68,25 +68,24 @@ exports(
 	},
 );
 
-exports(
-	'hasGroup',
-	(playerId: number | string, groupName: string): boolean => {
-		const slug = slugifyGroupName(groupName);
-		if (!slug) return false;
+exports('hasGroup', (playerId: number | string, groupName: string): boolean => {
+	const slug = slugifyGroupName(groupName);
+	if (!slug) return false;
 
-		return IsPlayerAceAllowed(
-			String(playerId),
-			`${ACE_PREFIX}.group.${slug}`,
-		);
-	},
-);
+	return IsPlayerAceAllowed(String(playerId), `${ACE_PREFIX}.group.${slug}`);
+});
 
 type SelfInfo = {
 	isAdmin: boolean;
 	isMaster: boolean;
 	adminId: number | null;
 	username: string | null;
-	group: { id: number; name: string; colour: string; icon: string | null } | null;
+	group: {
+		id: number;
+		name: string;
+		colour: string;
+		icon: string | null;
+	} | null;
 	permissions: string[];
 };
 

--- a/apps/resource/src/server/httphandler/index.ts
+++ b/apps/resource/src/server/httphandler/index.ts
@@ -43,5 +43,3 @@ api.get('/server/version', () => {
 api.post('/txadmin/event', { schema: txEventSchema }, ({ body }) =>
 	handleTxEvent(body),
 );
-
-console.log('Webserver initialized');

--- a/apps/resource/src/server/index.ts
+++ b/apps/resource/src/server/index.ts
@@ -3,5 +3,16 @@ import './events';
 import './httphandler';
 import './exports';
 import { censorConvars } from './utils/env';
+import { QueryManager } from './utils/query';
 
 censorConvars();
+
+setTimeout(() => {
+	console.log('^2Server initialized^7');
+
+	QueryManager({
+		endpoint: '/server/ready',
+		method: 'POST',
+		body: {},
+	});
+}, 0);


### PR DESCRIPTION
## Description

With Cfx's nucleus deprecation (June 30th), fxserver no longer logs "Authenticated with cfx.re nucleus" which was used to determine if the server was running (resources & commands in server.cfg sequence where executed).
So any server running artifacts with the deprecation patch ( [`9443aca`](https://github.com/citizenfx/fivem/commit/9443acab710de2eaaa165e529e6b3eae1268278a) ) will be affected by this.

To resolve this issue, we now rely on the fxManager resource to inform the webpanel that the server has started properly, this works because it's started as a start-up parameter and is (normally) always started last. So we have it send an http request in the callback of a timeout to guarantee it running on the resources first tick.

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [x] Builds & runs on Windows
- [ ] Builds & runs on Linux

---

## Additional Notes

- Resolves #64 
- Depends on #61 