### PR TITLE
Fix: fxserver paths validation

### DIFF
--- a/apps/core/src/modules/config/manager.test.ts
+++ b/apps/core/src/modules/config/manager.test.ts
@@ -236,7 +236,13 @@ describe('ConfigManager', () => {
 
 		it('auto-detects Linux fxserver inside a valid directory', async () => {
 			setPlatform('linux');
-			const dirPath = path.join(process.cwd(), 'fxserver-folder');
+			const dirPath = path.join(
+				process.cwd(),
+				'fxserver',
+				'alpine',
+				'opt',
+				'cfx-server',
+			);
 			const exePath = path.join(dirPath, 'fxserver');
 
 			fileSystem.set(dirPath, 'dir');
@@ -244,6 +250,22 @@ describe('ConfigManager', () => {
 
 			const config = ConfigManager.getInstance();
 			const res = await config.validateExecutablePath(dirPath);
+			expect(res.valid).toBe(true);
+			expect(res.path).toBe(exePath);
+		});
+
+		it('auto-detects Linux fxserver from alpine path', async () => {
+			setPlatform('linux');
+			const rootPath = path.join(process.cwd(), 'fxserver');
+			const dirPath = path.join(rootPath, 'alpine', 'opt', 'cfx-server');
+			const exePath = path.join(dirPath, 'fxserver');
+
+			fileSystem.set(rootPath, 'dir');
+			fileSystem.set(dirPath, 'dir');
+			fileSystem.set(exePath, 'file');
+
+			const config = ConfigManager.getInstance();
+			const res = await config.validateExecutablePath(rootPath);
 			expect(res.valid).toBe(true);
 			expect(res.path).toBe(exePath);
 		});

--- a/apps/core/src/modules/config/manager.ts
+++ b/apps/core/src/modules/config/manager.ts
@@ -142,10 +142,16 @@ export class ConfigManager {
 			if (execStats.isDirectory()) {
 				const validNames =
 					process.platform === 'win32'
-						// cover both as a sanity check
-						? ['fxserver.exe', 'FXServer.exe']
-						// should only be FXServer, but just in case we do both
-						: ['fxserver', 'FXServer'];
+						? // cover both as a sanity check
+							['fxserver.exe', 'FXServer.exe']
+						: // should only be FXServer, but just in case we do both
+							// we also cover the alpine path if omitted
+							[
+								'fxserver',
+								'FXServer',
+								path.join('alpine', 'opt', 'cfx-server', 'fxserver'),
+								path.join('alpine', 'opt', 'cfx-server', 'FXServer'),
+							];
 
 				for (const name of validNames) {
 					const testPath = path.join(initialPath, name);
@@ -165,9 +171,9 @@ export class ConfigManager {
 						? /^fxserver\.exe$/i
 						: /^(fxserver|FXServer)$/;
 
-		    if (validNames.test(fileName)) {
-	        found = true;
-		    }
+				if (validNames.test(fileName)) {
+					found = true;
+				}
 			}
 		} catch {
 			found = false;

--- a/apps/core/src/routes/api/setup.ts
+++ b/apps/core/src/routes/api/setup.ts
@@ -53,19 +53,22 @@ const SetupEndpoint: FastifyPluginAsync = async (fastify) => {
 			? cfg.serverConfigFile
 			: path.join(cfg.serverDataPath, cfg.serverConfigFile);
 
-		const [executable, dataPath, cfgFound] = await Promise.all([
-			fileExists(cfg.executablePath),
-			fileExists(cfg.serverDataPath),
-			fileExists(cfgPath),
-		]);
+		const result = await ConfigManager.getInstance().checkFXServerPaths(
+			cfg.executablePath,
+			cfg.serverDataPath,
+		);
 
 		return {
 			success: true,
 			data: {
-				executable: cfg.executablePath,
-				dataPath: cfg.serverDataPath,
-				cfgPath,
-				found: { executable, dataPath, cfg: cfgFound },
+				executable: result.files.executable,
+				dataPath: result.files.serverdata,
+				cfgPath: result.files.cfg,
+				found: {
+					executable: result.exists.executable,
+					dataPath: result.exists.serverdata,
+					cfg: result.exists.cfg,
+				},
 			},
 		} satisfies ApiResponse<DetectResult>;
 	});


### PR DESCRIPTION
## Description

This PR addresses an oversight in #63 where auto detect was validating the executable path when it was only a directory, the commits fix this oversight by reusing the `ConfigManager.checkFXServerPaths(exec, data)` within the detection to not only properly validate but also provides absolute paths for the values.

Alongside this fix, it also expands the checked paths for linux executables. Instead of requiring the path to `opt/cfx-server/` it will also work to the parent folder of `alpine`, so in sum it will accept & auto-complete the following:

| given path | full path |
| --- | --- |
| `./fxServer/` | `./fxServer/alpine/opt/cfx-server/fxserver` |
| `./fxServer/alpine/opt/cfx-server/` | `./fxServer/alpine/opt/cfx-server/fxserver` |

<!--
	Answer truthfully, this has it's purpose when reviewing PRs
	and is not used to judge the contributor's work.
	Lying on this is pointless, and we allow ourselves to not consider
	PRs where GenAI was used and not declared.
-->
- [ ] ~~Generative AI was used in the creation of the changes of this PR~~

---

## Tests

- [x] Tested in development mode
- [x] Passes typecheck
- [x] Builds & runs on Windows
- [ ] Builds & runs on Linux

---

## Additional Notes

This is useful for allowing auto-detect for [cli-installer](https://github.com/fxManagerProject/cli-installer) & #68 
