### PR TITLE
Ci: fix testing on gh

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,7 +29,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Execute Test Runner
-        run: bun test
+        run: bun run test
 
   typecheck:
     name: Verify Types

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "turbo lint",
     "format": "turbo format && biome format --write ./scripts/*.ts",
     "typecheck": "turbo typecheck",
+    "test": "bun ./scripts/test.ts",
     "db:studio": "drizzle-kit studio",
     "db:migrate": "drizzle-kit generate && bun ./scripts/migrate.ts && bun biome format --write ./packages/database"
   },

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -1,0 +1,51 @@
+import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+
+const ROOT_DIR = join(import.meta.dir, '..');
+
+const testFiles: string[] = [];
+for await (const file of new Bun.Glob('**/*.test.ts').scan({
+	onlyFiles: true,
+	cwd: ROOT_DIR,
+})) {
+	testFiles.push(file.replaceAll('\\', '/'));
+}
+testFiles.sort();
+
+if (testFiles.length === 0) {
+	console.log('No test files found.');
+	process.exit(0);
+}
+
+console.log(`Running ${testFiles.length} test file(s):\n`);
+for (const file of testFiles) {
+	console.log(`  ${file}`);
+}
+
+const failedFiles: string[] = [];
+for (const file of testFiles) {
+	const exitCode = await new Promise<number>((resolve) => {
+		const child = spawn(process.execPath, ['test', file], {
+			cwd: ROOT_DIR,
+			stdio: 'inherit',
+		});
+		child.on('exit', (code) => resolve(code ?? 1));
+	});
+	if (exitCode !== 0) {
+		failedFiles.push(file);
+	}
+	console.log();
+}
+
+if (failedFiles.length === 0) {
+	console.log(`✅ All ${testFiles.length} test file(s) passed.`);
+	process.exit(0);
+} else {
+	console.error(
+		`❌ ${failedFiles.length} of ${testFiles.length} test file(s) failed:`,
+	);
+	for (const file of failedFiles) {
+		console.error(`   - ${file}`);
+	}
+	process.exit(1);
+}


### PR DESCRIPTION
## Description

This PR addresses the issue of tests failing in the PR Checks action on github, the observed issue is that there is a failure on isolation of mocks leading to them "infecting" subsequent tests and leading them to fail.
To address this, a new script is added to run all tests in order based on their path.

### Generative AI Disclosure
> [!NOTE]
> Be honest—using GenAI does not penalize your PR, but failing to declare its use may result in the PR not being considered.

* [x] **No**, Generative AI was **not** used in the creation of this PR.
* [ ] **Yes**, Generative AI **was** used in the creation of this PR. 
  *(If yes, please briefly describe what tools were used and for what purpose below)*:
  * **Tools used:** <!-- (e.g., ChatGPT, GitHub Copilot, Claude) -->
  * **Purpose / What it was used for:** <!-- (e.g., drafted documentation, generated unit tests, refactored function X) -->

---

## Tests

- [x] Tested in development mode
- [ ] Passes typecheck (works in hand with #76 )
- [x] Builds & runs on Windows
- [ ] Builds & runs on Linux

---

## Additional Notes

<!--
	Any extra details you wish to share, i.e.:
	* Unable to test on linux -> state why for context
	* Request feedback
	* Explain why the PR is listed as a Draft
	* List todo steps requiring discussion
-->
